### PR TITLE
allow .tables and .schema without interactive shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ You can start an interactive SQL shell similar to `sqlite3` with:
 turso db shell <database name>
 ```
 
+### Run SQL command without interactive shell
+
+You can also run a command without using the interactive SQL shell:
+
+```bash
+turso db shell <database name> <sql query>
+```
+
 ### Replicate database
 
 First, list available locations and pick a location you want to replicate to:

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -33,7 +33,7 @@ var shellCmd = &cobra.Command{
 	Use:               "shell {database_name | replica_url} [sql]",
 	Short:             "Start a SQL shell.",
 	Long:              "Start a SQL shell.\nWhen database_name is provided, the shell will connect to the closest replica of the specified database.\nWhen a url of a particular replica is provided, the shell will connect to that replica directly.",
-	Example:           "turso db shell name-of-my-amazing-db\nturso db shell libsql://<replica-url>\nturso db shell libsql://e784400f26d083-my-amazing-db-replica-url.turso.io",
+	Example:           "turso db shell name-of-my-amazing-db\nturso db shell libsql://<replica-url>\nturso db shell libsql://e784400f26d083-my-amazing-db-replica-url.turso.io\nturso db shell name-of-my-amazing-db \"select * from users;\"",
 	Args:              cobra.RangeArgs(1, 2),
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -258,6 +258,12 @@ func (e *SqlError) Error() string {
 }
 
 func query(url, stmt string) error {
+	switch stmt {
+	case ".tables":
+		stmt = getTables()
+	case ".schema":
+		stmt = getSchema()
+	}
 	resp, err := doQuery(url, stmt)
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows passing in `.tables` and `.schema` without calling in to the interactive shell:

```bash
turso db shell test-db ".tables"
turso db shell test-db ".schema"
```

The checks for those statements were also moved into `query()` so they would work. Also updates some of the docs to reflect that passing in SQL as an argument to the `shell` command is possible.