### PR TITLE
Use database token on shell and inspect commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/athoscouto/codename v0.0.3
+	github.com/dustin/go-humanize v1.0.1
 	github.com/frankban/quicktest v1.14.4
 	github.com/google/uuid v1.3.0
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
@@ -46,7 +47,6 @@ require (
 )
 
 require (
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -43,9 +43,14 @@ var accountShowCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+
+			token, err := client.Databases.Token(database.Name, "")
+			if err != nil {
+				return err
+			}
+
 			for _, instance := range instances {
 				url := getInstanceHttpUrl(settings, &database, &instance)
-				token := ""
 				ret, err := inspect(url, token, instance.Region, false)
 				if err != nil {
 					return err

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -45,7 +45,8 @@ var accountShowCmd = &cobra.Command{
 			}
 			for _, instance := range instances {
 				url := getInstanceHttpUrl(settings, &database, &instance)
-				ret, err := inspect(url, instance.Region, false)
+				token := ""
+				ret, err := inspect(url, token, instance.Region, false)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -44,7 +44,7 @@ var accountShowCmd = &cobra.Command{
 				return err
 			}
 
-			token, err := client.Databases.Token(database.Name, "")
+			token, err := client.Databases.Token(database.Name, "default")
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -79,7 +79,7 @@ var dbInspectCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := client.Databases.Token(db.Name, "")
+		token, err := client.Databases.Token(db.Name, "default")
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -79,7 +79,11 @@ var dbInspectCmd = &cobra.Command{
 			return err
 		}
 
-		token := ""
+		token, err := client.Databases.Token(db.Name, "")
+		if err != nil {
+			return err
+		}
+
 		inspectRet := InspectInfo{}
 		for _, instance := range instances {
 			url := getInstanceHttpUrl(config, &db, &instance)

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -166,7 +166,7 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 		return "", nil
 	}
 
-	return client.Databases.Token(db.Name, "")
+	return client.Databases.Token(db.Name, "default")
 }
 
 func printConnectionInfo(nameOrUrl string, db *turso.Database, config *settings.Settings) {


### PR DESCRIPTION
This fixes 401 response that happens when a user logs in on a second device.
