### PR TITLE
Drop obsolete auth check in REST API client

### DIFF
--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -64,9 +64,6 @@ func (t *Client) do(method, path string, body io.Reader) (*http.Response, error)
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("%s - please login with %s", resp.Status, Emph("turso auth login"))
-	}
 	return resp, nil
 }
 


### PR DESCRIPTION
The CLI already validates the access token before making more REST API calls so the check is obsolete. Furthermore, the check is also incorrect because even if you're logged in, you might be unauthorized to do some things.