### PR TITLE
Move colors out of `turso` package

### DIFF
--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/rodaine/table"
@@ -59,7 +59,7 @@ var accountShowCmd = &cobra.Command{
 			}
 		}
 
-		fmt.Printf("You are currently on %s plan.\n", turso.Emph("starter"))
+		fmt.Printf("You are currently on %s plan.\n", internal.Emph("starter"))
 		fmt.Println()
 
 		columns := make([]interface{}, 0)

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"text/template"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +66,7 @@ var tokenCmd = &cobra.Command{
 		}
 		token := settings.GetToken()
 		if !isJwtTokenValid(token) {
-			return fmt.Errorf("no user logged in. Run %s to log in and get a token", turso.Emph("turso auth login"))
+			return fmt.Errorf("no user logged in. Run %s to log in and get a token", internal.Emph("turso auth login"))
 		}
 		fmt.Println(token)
 		return nil
@@ -111,7 +111,7 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 	if isJwtTokenValid(settings.GetToken()) {
 		username := settings.GetUsername()
 		if len(username) > 0 {
-			fmt.Printf("Already signed in as %s. Use %s to log out of this account\n", username, turso.Emph("turso auth logout"))
+			fmt.Printf("Already signed in as %s. Use %s to log out of this account\n", username, internal.Emph("turso auth logout"))
 		} else {
 			fmt.Println("✔  Success! Existing JWT still valid")
 		}
@@ -177,8 +177,8 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 
 	if version != latestVersion {
 
-		fmt.Printf("\nFriendly reminder that there's a newer version of %s available.\n", turso.Emph("Turso CLI"))
-		fmt.Printf("You're currently using version %s while latest available version is %s.\n", turso.Emph(version), turso.Emph(latestVersion))
+		fmt.Printf("\nFriendly reminder that there's a newer version of %s available.\n", internal.Emph("Turso CLI"))
+		fmt.Printf("You're currently using version %s while latest available version is %s.\n", internal.Emph(version), internal.Emph(latestVersion))
 		fmt.Printf("Please consider updating to get new features and more stable experience.\n\n")
 	}
 
@@ -189,7 +189,7 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 	}
 	dbs, err := getDatabases(client)
 	if firstTime && err == nil && len(dbs) == 0 {
-		fmt.Printf("✏️  We are so happy you are here! Now that you are authenticated, it is time to create a database:\n\t%s\n", turso.Emph("turso db create"))
+		fmt.Printf("✏️  We are so happy you are here! Now that you are authenticated, it is time to create a database:\n\t%s\n", internal.Emph("turso db create"))
 	}
 	return nil
 }

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
@@ -78,7 +79,7 @@ func getDatabase(client *turso.Client, name string) (turso.Database, error) {
 		}
 	}
 
-	return turso.Database{}, fmt.Errorf("database %s not found. List known databases using %s", turso.Emph(name), turso.Emph("turso db list"))
+	return turso.Database{}, fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(name), internal.Emph("turso db list"))
 }
 
 func getDatabaseNames(client *turso.Client) []string {
@@ -137,7 +138,7 @@ func getAccessToken() (string, error) {
 
 	token := settings.GetToken()
 	if token == "" {
-		return "", fmt.Errorf("user not logged in, please use %s", turso.Emph("turso auth login"))
+		return "", fmt.Errorf("user not logged in, please use %s", internal.Emph("turso auth login"))
 	}
 
 	return token, nil

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/athoscouto/codename"
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +56,7 @@ var createCmd = &cobra.Command{
 		}
 		start := time.Now()
 		regionText := fmt.Sprintf("%s (%s)", toLocation(client, region), region)
-		description := fmt.Sprintf("Creating database %s in %s ", turso.Emph(name), turso.Emph(regionText))
+		description := fmt.Sprintf("Creating database %s in %s ", internal.Emph(name), internal.Emph(regionText))
 		bar := startLoadingBar(description)
 		defer bar.Stop()
 		res, err := client.Databases.Create(name, region, image)
@@ -75,7 +75,7 @@ var createCmd = &cobra.Command{
 
 		bar.Stop()
 		elapsed := time.Since(start)
-		fmt.Printf("Created database %s in %s in %d seconds.\n\n", turso.Emph(name), turso.Emph(regionText), int(elapsed.Seconds()))
+		fmt.Printf("Created database %s in %s in %d seconds.\n\n", internal.Emph(name), internal.Emph(regionText), int(elapsed.Seconds()))
 
 		fmt.Printf("You can start an interactive SQL shell with:\n\n")
 		fmt.Printf("   turso db shell %s\n\n", name)
@@ -86,7 +86,7 @@ var createCmd = &cobra.Command{
 		firstTime := config.RegisterUse("db_create")
 		if firstTime {
 			fmt.Printf("✏️  Now that you created a database, the next step is to create a replica. Why don't we try?\n\t%s\n\t%s\n",
-				turso.Emph("turso db locations"), turso.Emph(fmt.Sprintf("turso db replicate %s [location]", name)))
+				internal.Emph("turso db locations"), internal.Emph(fmt.Sprintf("turso db replicate %s [location]", name)))
 		}
 		return nil
 	},

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ var destroyCmd = &cobra.Command{
 			return destroyDatabase(client, name)
 		}
 
-		fmt.Printf("Database %s, all its replicas, and data will be destroyed.\n", turso.Emph(name))
+		fmt.Printf("Database %s, all its replicas, and data will be destroyed.\n", internal.Emph(name))
 
 		ok, err := promptConfirmation("Are you sure you want to do this?")
 		if err != nil {

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
@@ -34,7 +35,7 @@ var dbInvalidateTokensCmd = &cobra.Command{
 			return rotate(client, name)
 		}
 
-		fmt.Printf("To invalidate %s database tokens, all its replicas must be restarted.\n", turso.Emph(name))
+		fmt.Printf("To invalidate %s database tokens, all its replicas must be restarted.\n", internal.Emph(name))
 		fmt.Printf("All your active connections to the DB will be dropped and there will be a short downtime.\n\n")
 
 		ok, err := promptConfirmation("Are you sure you want to do this?")

--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
@@ -40,7 +41,7 @@ var regionsCmd = &cobra.Command{
 			}
 			line := fmt.Sprintf("%s  %s%s", regions.Ids[idx], regions.Descriptions[idx], suffix)
 			if regions.Ids[idx] == defaultRegionId {
-				line = turso.Emph(line)
+				line = internal.Emph(line)
 			}
 			fmt.Printf("%s\n", line)
 		}

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +49,7 @@ var replicateCmd = &cobra.Command{
 			return err
 		}
 		if !isValidRegion(client, region) {
-			return fmt.Errorf("invalid location ID. Run %s to see a list of valid location IDs", turso.Emph("turso db locations"))
+			return fmt.Errorf("invalid location ID. Run %s to see a list of valid location IDs", internal.Emph("turso db locations"))
 		}
 
 		image := "latest"
@@ -70,7 +70,7 @@ var replicateCmd = &cobra.Command{
 		}
 
 		regionText := fmt.Sprintf("%s (%s)", toLocation(client, region), region)
-		s := startLoadingBar(fmt.Sprintf("Replicating database %s to %s ", turso.Emph(dbName), turso.Emph(regionText)))
+		s := startLoadingBar(fmt.Sprintf("Replicating database %s to %s ", internal.Emph(dbName), internal.Emph(regionText)))
 		start := time.Now()
 		instance, err := client.Instances.Create(dbName, instanceName, password, region, image)
 		s.Stop()
@@ -79,7 +79,7 @@ var replicateCmd = &cobra.Command{
 		}
 		end := time.Now()
 		elapsed := end.Sub(start)
-		fmt.Printf("Replicated database %s to %s in %d seconds.\n\n", turso.Emph(dbName), turso.Emph(regionText), int(elapsed.Seconds()))
+		fmt.Printf("Replicated database %s to %s in %d seconds.\n\n", internal.Emph(dbName), internal.Emph(regionText), int(elapsed.Seconds()))
 
 		fmt.Printf("URL:\n\n")
 		dbUrl := getInstanceUrl(config, &database, instance)

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/chzyer/readline"
@@ -190,7 +191,7 @@ func printConnectionInfo(nameOrUrl string, db *turso.Database, config *settings.
 	msg := fmt.Sprintf("Connected to %s", nameOrUrl)
 	if db != nil {
 		url := getDatabaseUrl(config, db, false)
-		msg = fmt.Sprintf("Connected to %s at %s", turso.Emph(db.Name), url)
+		msg = fmt.Sprintf("Connected to %s at %s", internal.Emph(db.Name), url)
 	}
 
 	fmt.Printf("%s\n\n", msg)

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +66,7 @@ var showCmd = &cobra.Command{
 					return nil
 				}
 			}
-			return fmt.Errorf("instance %s was not found for database %s. List known instances using %s", turso.Emph(showInstanceUrlFlag), turso.Emph(db.Name), turso.Emph("turso db show "+db.Name))
+			return fmt.Errorf("instance %s was not found for database %s. List known instances using %s", internal.Emph(showInstanceUrlFlag), internal.Emph(db.Name), internal.Emph("turso db show "+db.Name))
 		}
 
 		regions := make([]string, len(db.Regions))

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,7 @@ var dbUpdateCmd = &cobra.Command{
 			return update(client, name)
 		}
 
-		fmt.Printf("To update %s database, all its replicas must be updated.\n", turso.Emph(name))
+		fmt.Printf("To update %s database, all its replicas must be updated.\n", internal.Emph(name))
 		fmt.Printf("All your active connections to the DB will be dropped and there will be a short downtime.\n\n")
 
 		ok, err := promptConfirmation("Are you sure you want to do this?")
@@ -51,7 +52,7 @@ var dbUpdateCmd = &cobra.Command{
 }
 
 func update(client *turso.Client, name string) error {
-	msg := fmt.Sprintf("Updating database %s", turso.Emph(name))
+	msg := fmt.Sprintf("Updating database %s", internal.Emph(name))
 	s := startLoadingBar(msg)
 
 	if err := client.Databases.Update(name); err != nil {
@@ -60,6 +61,6 @@ func update(client *turso.Client, name string) error {
 	}
 
 	s.Stop()
-	fmt.Printf("✔  Success! Database %s updated successfully\n", turso.Emph(name))
+	fmt.Printf("✔  Success! Database %s updated successfully\n", internal.Emph(name))
 	return nil
 }

--- a/internal/cmd/quickstart.go
+++ b/internal/cmd/quickstart.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -19,9 +19,9 @@ var quickstartCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		fmt.Print("\nWelcome to Turso!\n\n")
-		fmt.Printf("If you are a new user, please sign up with %s; otherwise login\n", turso.Emph("turso auth signup"))
-		fmt.Printf("with %s. When you are authenticated, you can create a new\n", turso.Emph("turso auth login"))
-		fmt.Printf("database with %s. You can also run %s for help.\n", turso.Emph("turso db create"), turso.Emph("turso help"))
+		fmt.Printf("If you are a new user, please sign up with %s; otherwise login\n", internal.Emph("turso auth signup"))
+		fmt.Printf("with %s. When you are authenticated, you can create a new\n", internal.Emph("turso auth login"))
+		fmt.Printf("database with %s. You can also run %s for help.\n", internal.Emph("turso db create"), internal.Emph("turso help"))
 		fmt.Printf("\nFor a more comprehensive getting started guide, open the following URL:\n\n")
 		fmt.Printf("  https://docs.turso.tech/tutorials/get-started-turso-cli\n\n")
 		return nil

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/briandowns/spinner"
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/olekukonko/tablewriter"
@@ -101,7 +102,7 @@ func getDatabaseRegions(db turso.Database) string {
 	regions := make([]string, 0, len(db.Regions))
 	for _, region := range db.Regions {
 		if region == db.PrimaryRegion {
-			region = fmt.Sprintf("%s (primary)", turso.Emph(region))
+			region = fmt.Sprintf("%s (primary)", internal.Emph(region))
 		}
 		regions = append(regions, region)
 	}
@@ -144,7 +145,7 @@ func createSpinner(text string) *spinner.Spinner {
 
 func destroyDatabase(client *turso.Client, name string) error {
 	start := time.Now()
-	s := startLoadingBar(fmt.Sprintf("Destroying database %s... ", turso.Emph(name)))
+	s := startLoadingBar(fmt.Sprintf("Destroying database %s... ", internal.Emph(name)))
 	defer s.Stop()
 	if err := client.Databases.Delete(name); err != nil {
 		return err
@@ -152,7 +153,7 @@ func destroyDatabase(client *turso.Client, name string) error {
 	s.Stop()
 	elapsed := time.Since(start)
 
-	fmt.Printf("Destroyed database %s in %d seconds.\n", turso.Emph(name), int(elapsed.Seconds()))
+	fmt.Printf("Destroyed database %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
 	settings, err := settings.ReadSettings()
 	if err == nil {
 		settings.InvalidateDbNamesCache()
@@ -193,7 +194,7 @@ func destroyDatabaseRegion(client *turso.Client, database, region string) error 
 		return err
 	}
 
-	fmt.Printf("Destroyed %d instances in location %s of database %s.\n", len(replicas), turso.Emph(region), turso.Emph(db.Name))
+	fmt.Printf("Destroyed %d instances in location %s of database %s.\n", len(replicas), internal.Emph(region), internal.Emph(db.Name))
 	if primary != nil {
 		destroyAllCmd := fmt.Sprintf("turso db destroy %s", database)
 		fmt.Printf("Primary was not destroyed. To destroy it, with the whole database, run '%s'\n", destroyAllCmd)
@@ -207,7 +208,7 @@ func destroyDatabaseInstance(client *turso.Client, database, instance string) er
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Destroyed instance %s of database %s.\n", turso.Emph(instance), turso.Emph(database))
+	fmt.Printf("Destroyed instance %s of database %s.\n", internal.Emph(instance), internal.Emph(database))
 	return nil
 }
 
@@ -215,10 +216,10 @@ func deleteDatabaseInstance(client *turso.Client, database, instance string) err
 	err := client.Instances.Delete(database, instance)
 	if err != nil {
 		if err.Error() == "could not find database "+database+" to delete instance from" {
-			return fmt.Errorf("database %s not found. List known databases using %s", turso.Emph(database), turso.Emph("turso db list"))
+			return fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(database), internal.Emph("turso db list"))
 		}
 		if err.Error() == "could not find instance "+instance+" of database "+database {
-			return fmt.Errorf("instance %s not found for database %s. List known instances using %s", turso.Emph(instance), turso.Emph(database), turso.Emph("turso db show "+database))
+			return fmt.Errorf("instance %s not found for database %s. List known instances using %s", internal.Emph(instance), internal.Emph(database), internal.Emph("turso db show "+database))
 		}
 		return err
 	}

--- a/internal/colors.go
+++ b/internal/colors.go
@@ -1,0 +1,8 @@
+package internal
+
+import "github.com/fatih/color"
+
+// Color function for emphasising text.
+var Emph = color.New(color.FgBlue, color.Bold).SprintFunc()
+
+var Warn = color.New(color.FgYellow, color.Bold).SprintFunc()

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -3,6 +3,8 @@ package turso
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/chiselstrike/iku-turso-cli/internal"
 )
 
 type Database struct {
@@ -42,7 +44,7 @@ func (d *DatabasesClient) Delete(database string) error {
 	defer r.Body.Close()
 
 	if r.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("database %s not found. List known databases using %s", Emph(database), Emph("turso db list"))
+		return fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(database), internal.Emph("turso db list"))
 	}
 
 	if r.StatusCode != http.StatusOK {
@@ -101,7 +103,7 @@ func (d *DatabasesClient) ChangePassword(database string, newPassword string) er
 	defer r.Body.Close()
 
 	if r.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("database %s not found. List known databases using %s", Emph(database), Emph("turso db list"))
+		return fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(database), internal.Emph("turso db list"))
 	}
 
 	if r.StatusCode != http.StatusOK {

--- a/internal/turso/utils.go
+++ b/internal/turso/utils.go
@@ -6,14 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/fatih/color"
 )
-
-// Color function for emphasising text.
-var Emph = color.New(color.FgBlue, color.Bold).SprintFunc()
-
-var Warn = color.New(color.FgYellow, color.Bold).SprintFunc()
 
 func unmarshal[T any](r *http.Response) (T, error) {
 	d, err := io.ReadAll(r.Body)


### PR DESCRIPTION
The `turso` package is a wrapper on the Turso REST API. Let's move totally unrelated code on terminal colors out of it...