### PR TITLE
Fix access token validation

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -137,8 +137,8 @@ func getAccessToken() (string, error) {
 	}
 
 	token := settings.GetToken()
-	if token == "" {
-		return "", fmt.Errorf("user not logged in, please use %s", internal.Emph("turso auth login"))
+	if !isJwtTokenValid(token) {
+		return "", fmt.Errorf("user not logged in, please login with %s", internal.Emph("turso auth login"))
 	}
 
 	return token, nil


### PR DESCRIPTION
Commit c2b284118f7579f2a07f60d260b4383069ad083a caused a regression in
the CLI because JWT validation in getAccessToken() is broken.

Before:

```
$ turso db create
Error: could not create database comic-humbug: Authentication required
```

After:

```
$ turso db create
Error: user not logged in, please login with turso auth login
```