### PR TITLE
Warn users that their platform token will not work with databases

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"text/template"
 
@@ -68,6 +69,10 @@ var tokenCmd = &cobra.Command{
 		if !isJwtTokenValid(token) {
 			return fmt.Errorf("no user logged in. Run %s to log in and get a token", internal.Emph("turso auth login"))
 		}
+
+		fmt.Fprintln(os.Stderr, internal.Warn("Warning: this token is used to authenticate with the Turso platform, not your databases."))
+		fmt.Fprintf(os.Stderr, "%s %s %s.\n", internal.Warn("Use"), internal.Emph("turso db token create"), internal.Warn("to create a database token"))
+
 		fmt.Println(token)
 		return nil
 	},

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -70,8 +70,8 @@ var tokenCmd = &cobra.Command{
 			return fmt.Errorf("no user logged in. Run %s to log in and get a token", internal.Emph("turso auth login"))
 		}
 
-		fmt.Fprintln(os.Stderr, internal.Warn("Warning: this token is used to authenticate with the Turso platform, not your databases."))
-		fmt.Fprintf(os.Stderr, "%s %s %s.\n", internal.Warn("Use"), internal.Emph("turso db token create"), internal.Warn("to create a database token"))
+		fmt.Fprintln(os.Stderr, internal.Warn("Warning: this token is used to authenticate you to Turso platform API, not your databases."))
+		fmt.Fprintf(os.Stderr, "%s %s %s\n", internal.Warn("Use"), internal.Emph("turso db token create"), internal.Warn("to create a database token."))
 
 		fmt.Println(token)
 		return nil

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -59,7 +59,7 @@ var tokenCmd = &cobra.Command{
 	Short: "Shows token used to authenticate you to Turso platform API.",
 	Long: "" +
 		"Shows token used to authenticate you to Turso platform API.\n" +
-		"To authenticate to your databases, use " + internal.Emph("turso db token create"),
+		"To authenticate to your databases, use " + internal.Emph("turso db tokens create"),
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,7 +74,7 @@ var tokenCmd = &cobra.Command{
 		}
 
 		fmt.Fprintln(os.Stderr, internal.Warn("Warning: this token is used to authenticate you to Turso platform API, not your databases."))
-		fmt.Fprintf(os.Stderr, "%s %s %s\n", internal.Warn("Use"), internal.Emph("turso db token create"), internal.Warn("to create a database token."))
+		fmt.Fprintf(os.Stderr, "%s %s %s\n", internal.Warn("Use"), internal.Emph("turso db tokens create"), internal.Warn("to create a database token."))
 
 		fmt.Println(token)
 		return nil

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -55,8 +55,11 @@ var logoutCmd = &cobra.Command{
 }
 
 var tokenCmd = &cobra.Command{
-	Use:               "token",
-	Short:             "Show token used for authorization.",
+	Use:   "token",
+	Short: "Shows token used to authenticate you to Turso platform API.",
+	Long: "" +
+		"Shows token used to authenticate you to Turso platform API.\n" +
+		"To authenticate to your databases, use " + internal.Emph("turso db token create"),
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -56,9 +56,9 @@ var logoutCmd = &cobra.Command{
 
 var tokenCmd = &cobra.Command{
 	Use:   "token",
-	Short: "Shows token used to authenticate you to Turso platform API.",
+	Short: "Shows the token used to authenticate you to Turso platform API.",
 	Long: "" +
-		"Shows token used to authenticate you to Turso platform API.\n" +
+		"Shows the token used to authenticate you to Turso platform API.\n" +
 		"To authenticate to your databases, use " + internal.Emph("turso db tokens create"),
 	Args:              cobra.NoArgs,
 	ValidArgsFunction: noFilesArg,


### PR DESCRIPTION
<img width="1046" alt="Screenshot 2023-04-19 at 12 23 33 PM" src="https://user-images.githubusercontent.com/7853668/233123588-3b611270-03ff-48d7-83c9-184cfac257c0.png">

Warning is sent to `stderr`, so things like: 

<img width="1029" alt="Screenshot 2023-04-19 at 12 24 06 PM" src="https://user-images.githubusercontent.com/7853668/233123753-68671771-bb18-4e89-b3da-14f388c00d76.png">

Should work.