### PR TITLE
feat: add read only shorthand flag

### DIFF
--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -16,7 +16,7 @@ func init() {
 	dbGenerateTokenCmd.Flags().VarP(&expFlag, "expiration", "e", usage)
 	dbGenerateTokenCmd.RegisterFlagCompletionFunc("expiration", expirationFlagCompletion)
 
-	dbGenerateTokenCmd.Flags().BoolVar(&readOnly, "read-only", false, "Token with read-only access")
+	dbGenerateTokenCmd.Flags().BoolVarP(&readOnly, "read-only", "r", false, "Token with read-only access")
 }
 
 var dbGenerateTokenCmd = &cobra.Command{


### PR DESCRIPTION
This PR aims to add a shorthand for the read-only flag of the cobra subcommand `turso db tokens create`, 

![image](https://user-images.githubusercontent.com/34041575/234015512-c29ba00d-c938-4892-ab9d-44654043eca1.png)

closes #346
