### PR TITLE
feat: improve tokens invalidate success message

### DIFF
--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -62,6 +62,7 @@ func rotate(turso *turso.Client, name string) error {
 	}
 
 	s.Stop()
-	fmt.Println("✔  Success! Tokens invalidated successfully")
+	fmt.Println("✔  Success! Tokens invalidated successfully. ")
+	fmt.Printf("Run %s to get a new one!\n", internal.Emph("turso db tokens create database_name [flags]"))
 	return nil
 }


### PR DESCRIPTION
This PR aims to improve the `turso db tokens invalidate ... ` success message. 

![image](https://user-images.githubusercontent.com/34041575/234060384-6dca7ba7-6257-4e7b-a312-c97003a120a5.png)

closes #256 