### PR TITLE
fix: headless login showing error message wrongly

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -179,6 +179,16 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 			return fmt.Errorf("error persisting username on local config: %w", err)
 		}
 		fmt.Printf("✔  Success! Logged in as %s\n", username)
+
+		firstTime := settings.RegisterUse("auth_login")
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
+		dbs, err := getDatabases(client)
+		if firstTime && err == nil && len(dbs) == 0 {
+			fmt.Printf("✏️  We are so happy you are here! Now that you are authenticated, it is time to create a database:\n\t%s\n", internal.Emph("turso db create"))
+		}
 	}
 
 	latestVersion := <-versionChannel
@@ -190,15 +200,6 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 		fmt.Printf("Please consider updating to get new features and more stable experience.\n\n")
 	}
 
-	firstTime := settings.RegisterUse("auth_login")
-	client, err := createTursoClient()
-	if err != nil {
-		return err
-	}
-	dbs, err := getDatabases(client)
-	if firstTime && err == nil && len(dbs) == 0 {
-		fmt.Printf("✏️  We are so happy you are here! Now that you are authenticated, it is time to create a database:\n\t%s\n", internal.Emph("turso db create"))
-	}
 	return nil
 }
 


### PR DESCRIPTION
This PR aims to fix the headless login showing `not logged in` error message wrongly 

closes #324 