### PR TITLE
Create a database from a seed file

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -85,7 +85,7 @@ var createCmd = &cobra.Command{
 				return fmt.Errorf("can't stat %s: %w", dbFromFile, err)
 			}
 
-			if stat.Size() > (128 << 10) {
+			if stat.Size() > (128 << 20) {
 				return fmt.Errorf("only files up to 128MiB are supported")
 			}
 

--- a/internal/cmd/db_from_file_flag.go
+++ b/internal/cmd/db_from_file_flag.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var dbFromFile string
+
+func addDbFromFileFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&dbFromFile, "from-file", "", "create the database from a local SQLite3-compatible file")
+}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -253,4 +254,18 @@ func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 		return getDatabaseNames(client), cobra.ShellCompDirectiveNoFileComp
 	}
 	return []string{}, cobra.ShellCompDirectiveNoFileComp
+}
+
+func isSQLiteFile(file *os.File) (bool, error) {
+	header := make([]byte, 16)
+	_, err := file.Read(header)
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+
+	if string(header) == "SQLite format 3\000" {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -257,6 +257,7 @@ func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 }
 
 func isSQLiteFile(file *os.File) (bool, error) {
+	defer file.Seek(0, io.SeekStart)
 	header := make([]byte, 16)
 	_, err := file.Read(header)
 	if err != nil && err != io.EOF {


### PR DESCRIPTION
extend the creation command to add a --from-file flag that allows one to pass a sqlite file