### PR TITLE
fix: auth token multiple misleading source

### DIFF
--- a/internal/cmd/account_feedback.go
+++ b/internal/cmd/account_feedback.go
@@ -16,7 +16,7 @@ var accountFeedbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return fmt.Errorf("could not create turso client: %w", err)
 		}

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -23,7 +23,7 @@ var accountShowCmd = &cobra.Command{
 			return err
 		}
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -94,7 +94,7 @@ func isJwtTokenValid(token string) bool {
 	if len(token) == 0 {
 		return false
 	}
-	client, err := createTursoClient()
+	client, err := tursoClient(token)
 	if err != nil {
 		return false
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -181,7 +181,7 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 		fmt.Printf("✔  Success! Logged in as %s\n", username)
 
 		firstTime := settings.RegisterUse("auth_login")
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(false)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -8,7 +8,6 @@ import (
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var showUrlFlag bool
@@ -126,10 +125,6 @@ func getAccessToken() (string, error) {
 	envToken := os.Getenv(ENV_ACCESS_TOKEN)
 	if envToken != "" {
 		return envToken, nil
-	}
-	flagToken := viper.GetString("token")
-	if flagToken != "" {
-		return flagToken, nil
 	}
 	settings, err := settings.ReadSettings()
 	if err != nil {

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -40,7 +40,7 @@ var createCmd = &cobra.Command{
 		} else {
 			name = args[0]
 		}
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -22,7 +22,7 @@ var destroyCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_generatetoken.go
+++ b/internal/cmd/db_generatetoken.go
@@ -27,7 +27,7 @@ var dbGenerateTokenCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -60,7 +60,7 @@ var dbInspectCmd = &cobra.Command{
 		}
 		cmd.SilenceUsage = true
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -22,7 +22,7 @@ var dbInvalidateTokensCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -20,7 +20,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_locations.go
+++ b/internal/cmd/db_locations.go
@@ -24,7 +24,7 @@ var regionsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_passwd.go
+++ b/internal/cmd/db_passwd.go
@@ -26,7 +26,7 @@ var changePasswordCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}
@@ -54,10 +54,6 @@ var changePasswordCmd = &cobra.Command{
 
 		bar := prompt.Spinner("Changing password...")
 		defer bar.Stop()
-		client, err = createTursoClient()
-		if err != nil {
-			return err
-		}
 		err = client.Databases.ChangePassword(args[0], newPassword)
 		bar.Stop()
 		if err != nil {

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 func replicateArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClient()
+	client, err := createTursoClientFromAccessToken(false)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 	}
@@ -45,7 +45,7 @@ var replicateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -52,7 +52,7 @@ var shellCmd = &cobra.Command{
 			defer spinner.Stop()
 		}
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return fmt.Errorf("could not create turso client: %w", err)
 		}

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -30,7 +30,7 @@ var showCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -21,7 +21,7 @@ var dbUpdateCmd = &cobra.Command{
 	ValidArgsFunction: dbNameArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/location_flag.go
+++ b/internal/cmd/location_flag.go
@@ -7,7 +7,7 @@ var locationFlag string
 func addLocationFlag(cmd *cobra.Command, desc string) {
 	cmd.Flags().StringVar(&locationFlag, "location", "", desc)
 	cmd.RegisterFlagCompletionFunc("location", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(false)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -35,7 +35,7 @@ var orgsListCmd = &cobra.Command{
 			return err
 		}
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}
@@ -74,7 +74,7 @@ var orgCreateCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		name := args[0]
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ var orgDestroyCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		slug := args[0]
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ var orgSelectCmd = &cobra.Command{
 			return err
 		}
 
-		client, err := createTursoClient()
+		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,10 +22,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringP("token", "t", "", "Access token used for authorization")
-	if err := viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token")); err != nil {
-		fmt.Fprintf(os.Stderr, "error binding token flag: %s", err)
-	}
 	rootCmd.PersistentFlags().StringP("config-path", "c", "", "Path to the directory with config file")
 	if err := viper.BindPFlag("config-path", rootCmd.PersistentFlags().Lookup("config-path")); err != nil {
 		fmt.Fprintf(os.Stderr, "error binding token flag: %s", err)

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -19,8 +19,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func createTursoClient() (*turso.Client, error) {
-	token, err := getAccessToken()
+func createTursoClientFromAccessToken(warnMultipleAccessTokenSources bool) (*turso.Client, error) {
+	token, err := getAccessToken(warnMultipleAccessTokenSources)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func promptConfirmation(prompt string) (bool, error) {
 }
 
 func dbNameArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := createTursoClient()
+	client, err := createTursoClientFromAccessToken(false)
 	if err != nil {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}


### PR DESCRIPTION
This PR aims to warn the user about the source of the token

closes #271 