### PR TITLE
Organization CRSD support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
-	golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
 	golang.org/x/sync v0.1.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0 h1:LGJsf5LRplCck6jUCH3dBL2dmycNruWNF5xugkSlfXw=
-golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -204,7 +204,11 @@ func auth(cmd *cobra.Command, args []string, path string) error {
 }
 
 func fetchLatestVersion() (string, error) {
-	resp, err := createUnauthenticatedTursoClient().Get("/releases/latest", nil)
+	client, err := createUnauthenticatedTursoClient()
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Get("/releases/latest", nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -66,7 +66,7 @@ var orgsListCmd = &cobra.Command{
 }
 
 var orgCreateCmd = &cobra.Command{
-	Use:               "create",
+	Use:               "create <name>",
 	Short:             "Create a new organization",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg,
@@ -90,30 +90,30 @@ var orgCreateCmd = &cobra.Command{
 }
 
 var orgDestroyCmd = &cobra.Command{
-	Use:               "destroy",
+	Use:               "destroy <slug>",
 	Short:             "Destroy an organization",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg, // TODO: add orgs autocomplete
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		name := args[0]
+		slug := args[0]
 
 		client, err := createTursoClient()
 		if err != nil {
 			return err
 		}
 
-		if err = client.Organizations.Delete(name); err != nil {
+		if err = client.Organizations.Delete(slug); err != nil {
 			return err
 		}
 
-		fmt.Printf("Destroyed organization %s.\n", internal.Emph(name))
+		fmt.Printf("Destroyed organization %s.\n", internal.Emph(slug))
 		return nil
 	},
 }
 
 var orgSelectCmd = &cobra.Command{
-	Use:               "select",
+	Use:               "select <slug>",
 	Short:             "Select an organization as the context for your commands.",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: noFilesArg, // TODO: add orgs autocomplete

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
+	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/spf13/cobra"
 )
 
@@ -94,6 +95,27 @@ var orgDestroyCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Destroyed organization %s.\n", internal.Emph(name))
+		return nil
+	},
+}
+
+var orgSelectCmd = &cobra.Command{
+	Use:               "select",
+	Short:             "Select an organization as the context for your commands.",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg, // TODO: add orgs autocomplete
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name := args[0]
+
+		config, err := settings.ReadSettings()
+		if err != nil {
+			return err
+		}
+
+		config.SetOrganization(name)
+		fmt.Printf("Default organization set to %s.\n", internal.Emph(name))
+		fmt.Printf("All you %s commands will be executed in that organization context", internal.Emph("turso"))
 		return nil
 	},
 }

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -11,6 +11,7 @@ func init() {
 	rootCmd.AddCommand(orgsCmd)
 	orgsCmd.AddCommand(orgsListCmd)
 	orgsCmd.AddCommand(orgCreateCmd)
+	orgsCmd.AddCommand(orgDestroyCmd)
 }
 
 var orgsCmd = &cobra.Command{
@@ -70,6 +71,29 @@ var orgCreateCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Created organization %s.\n", internal.Emph(org.Name))
+		return nil
+	},
+}
+
+var orgDestroyCmd = &cobra.Command{
+	Use:               "destroy",
+	Short:             "Destroy an organization",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg, // TODO: add orgs autocomplete
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name := args[0]
+
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
+
+		if err = client.Organizations.Delete(name); err != nil {
+			return err
+		}
+
+		fmt.Printf("Destroyed organization %s.\n", internal.Emph(name))
 		return nil
 	},
 }

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 var orgsCmd = &cobra.Command{
-	Use:   "organizations",
+	Use:   "org",
 	Short: "Manage your organizations",
 }
 

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -6,9 +6,42 @@ import (
 
 func init() {
 	rootCmd.AddCommand(orgsCmd)
+	orgsCmd.AddCommand(orgsListCmd)
 }
 
 var orgsCmd = &cobra.Command{
 	Use:   "organizations",
 	Short: "Manage your organizations",
+}
+
+var orgsListCmd = &cobra.Command{
+	Use:               "list",
+	Short:             "List your organizations",
+	Args:              cobra.NoArgs,
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
+
+		orgs, err := client.Organizations.List()
+		if err != nil {
+			return err
+		}
+
+		data := make([][]string, 0, len(orgs))
+		for _, org := range orgs {
+			data = append(data, []string{org.Name, org.Slug})
+		}
+
+		if len(data) == 0 {
+			fmt.Println("You don't have any organizations.")
+			return nil
+		}
+
+		printTable([]string{"name", "slug"}, data)
+		return nil
+	},
 }

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	rootCmd.AddCommand(orgsCmd)
 	orgsCmd.AddCommand(orgsListCmd)
+	orgsCmd.AddCommand(orgCreateCmd)
 }
 
 var orgsCmd = &cobra.Command{
@@ -42,6 +46,30 @@ var orgsListCmd = &cobra.Command{
 		}
 
 		printTable([]string{"name", "slug"}, data)
+		return nil
+	},
+}
+
+var orgCreateCmd = &cobra.Command{
+	Use:               "create",
+	Short:             "Create a new organization",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: noFilesArg,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		name := args[0]
+
+		client, err := createTursoClient()
+		if err != nil {
+			return err
+		}
+
+		org, err := client.Organizations.Create(name)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Created organization %s.\n", internal.Emph(org.Name))
 		return nil
 	},
 }

--- a/internal/cmd/organizations.go
+++ b/internal/cmd/organizations.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(orgsCmd)
+}
+
+var orgsCmd = &cobra.Command{
+	Use:   "organizations",
+	Short: "Manage your organizations",
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -138,6 +138,10 @@ func (s *Settings) SetOrganization(org string) error {
 	return nil
 }
 
+func (s *Settings) Organization() string {
+	return viper.GetString("organization")
+}
+
 func (s *Settings) DeleteDatabase(name string) {
 	databases := viper.GetStringMap("databases")
 	for id, rawSettings := range databases {

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -129,6 +129,15 @@ func (s *Settings) RegisterUse(cmd string) bool {
 	return firstTime
 }
 
+func (s *Settings) SetOrganization(org string) error {
+	viper.Set("organization", org)
+	err := viper.WriteConfig()
+	if err != nil {
+		return fmt.Errorf("error saving select org to local settings: %w", err)
+	}
+	return nil
+}
+
 func (s *Settings) DeleteDatabase(name string) {
 	databases := viper.GetStringMap("databases")
 	for id, rawSettings := range databases {

--- a/internal/turso/instances.go
+++ b/internal/turso/instances.go
@@ -37,7 +37,8 @@ func (i *InstancesClient) List(db string) ([]Instance, error) {
 }
 
 func (i *InstancesClient) Delete(db, instance string) error {
-	r, err := i.client.Delete(fmt.Sprintf("v2/databases/%s/instances/%s", db, instance), nil)
+	url := i.URL(db, "/instances/"+instance)
+	r, err := i.client.Delete(url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to destroy instances %s of %s: %s", instance, db, err)
 	}
@@ -70,7 +71,7 @@ func (d *InstancesClient) Create(dbName, instanceName, password, region, image s
 		return nil, fmt.Errorf("could not serialize request body: %w", err)
 	}
 
-	url := fmt.Sprintf("/v2/databases/%s/instances", dbName)
+	url := d.URL(dbName, "")
 	res, err := d.client.Post(url, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new instances for %s: %s", dbName, err)
@@ -87,4 +88,12 @@ func (d *InstancesClient) Create(dbName, instanceName, password, region, image s
 	}
 
 	return &data.Instance, nil
+}
+
+func (d *InstancesClient) URL(database, suffix string) string {
+	prefix := "/v1"
+	if d.client.org != "" {
+		prefix = "/v1/organizations/" + d.client.org
+	}
+	return fmt.Sprintf("%s/databases/%s/instances", prefix, database)
 }

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -56,3 +56,25 @@ func (c *OrganizationsClient) Create(name string) (Organization, error) {
 
 	return data.Org, nil
 }
+
+func (c *OrganizationsClient) Delete(name string) error {
+	r, err := c.client.Delete("/v1/organizations/"+name, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete organization: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("could not find organization %s", name)
+	}
+
+	if r.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("you do not have permission to delete organization %s", name)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete organization: %s", r.Status)
+	}
+
+	return nil
+}

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -57,19 +57,23 @@ func (c *OrganizationsClient) Create(name string) (Organization, error) {
 	return data.Org, nil
 }
 
-func (c *OrganizationsClient) Delete(name string) error {
-	r, err := c.client.Delete("/v1/organizations/"+name, nil)
+func (c *OrganizationsClient) Delete(slug string) error {
+	r, err := c.client.Delete("/v1/organizations/"+slug, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete organization: %s", err)
 	}
 	defer r.Body.Close()
 
 	if r.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("could not find organization %s", name)
+		return fmt.Errorf("could not find organization %s", slug)
+	}
+
+	if r.StatusCode == http.StatusBadRequest {
+		return fmt.Errorf("cannot delete personal organization %s", slug)
 	}
 
 	if r.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("you do not have permission to delete organization %s", name)
+		return fmt.Errorf("you do not have permission to delete organization %s", slug)
 	}
 
 	if r.StatusCode != http.StatusOK {

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -1,0 +1,34 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type OrganizationsClient client
+
+type Organization struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+	Type string `json:"type"`
+}
+
+func (c *OrganizationsClient) List() ([]Organization, error) {
+	r, err := c.client.Get("/v1/organizations", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request organizations: %s", err)
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list organizations: %s", r.Status)
+
+	}
+
+	data, err := unmarshal[[]Organization](r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize list organizations response: %w", err)
+	}
+
+	return data, nil
+}

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -19,9 +19,10 @@ type Client struct {
 	// Single instance to be reused by all clients
 	base *client
 
-	Instances *InstancesClient
-	Databases *DatabasesClient
-	Feedback  *FeedbackClient
+	Instances     *InstancesClient
+	Databases     *DatabasesClient
+	Feedback      *FeedbackClient
+	Organizations *OrganizationsClient
 }
 
 // Client struct that will be aliases by all other clients
@@ -36,6 +37,7 @@ func New(base *url.URL, token *string, cliVersion *string) *Client {
 	c.Instances = (*InstancesClient)(c.base)
 	c.Databases = (*DatabasesClient)(c.base)
 	c.Feedback = (*FeedbackClient)(c.base)
+	c.Organizations = (*OrganizationsClient)(c.base)
 	return c
 }
 

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -13,8 +13,9 @@ import (
 // Collection of all turso clients
 type Client struct {
 	baseUrl    *url.URL
-	token      *string
-	cliVersion *string
+	token      string
+	cliVersion string
+	org        string
 
 	// Single instance to be reused by all clients
 	base *client
@@ -30,7 +31,7 @@ type client struct {
 	client *Client
 }
 
-func New(base *url.URL, token *string, cliVersion *string) *Client {
+func New(base *url.URL, token string, cliVersion string, org string) *Client {
 	c := &Client{baseUrl: base, token: token, cliVersion: cliVersion}
 
 	c.base = &client{c}
@@ -54,10 +55,10 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 	if err != nil {
 		return nil, err
 	}
-	if t.token != nil {
-		req.Header.Add("Authorization", fmt.Sprint("Bearer ", *t.token))
+	if t.token != "" {
+		req.Header.Add("Authorization", fmt.Sprint("Bearer ", t.token))
 	}
-	req.Header.Add("TursoCliVersion", *t.cliVersion)
+	req.Header.Add("TursoCliVersion", t.cliVersion)
 	req.Header.Add("Content-Type", "application/json")
 	return req, nil
 }

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -32,7 +32,7 @@ type client struct {
 }
 
 func New(base *url.URL, token string, cliVersion string, org string) *Client {
-	c := &Client{baseUrl: base, token: token, cliVersion: cliVersion}
+	c := &Client{baseUrl: base, token: token, cliVersion: cliVersion, org: org}
 
 	c.base = &client{c}
 	c.Instances = (*InstancesClient)(c.base)


### PR DESCRIPTION
Let you `c`reate, list (`r`etrieve), `s`elect the current org, and `d`elete orgs.
We're still missing logic to manage users inside an org.

Some examples of command outputs:
```console
$ turso org
Manage your organizations

Usage:
  turso org [command]

Available Commands:
  create      Create a new organization
  destroy     Destroy an organization
  list        List your organizations
  select      Select an organization as the context for your commands.

Flags:
  -h, --help   help for org

Global Flags:
  -c, --config-path string   Path to the directory with config file
  -t, --token string         Access token used for authorization

Use "turso org [command] --help" for more information about a command.
```

```console
$ turso org list
NAME         SLUG                 
personal     athoscouto (current)     
test2        test2                    
```

```console
$ turso org select test2
Default organization set to test2.
All your turso commands will be executed in that organization context.
```

```console
turso org list
NAME         SLUG            
personal     athoscouto          
test2        test2 (current)     
```

