### PR TITLE
Improve error handling for org commands

### DIFF
--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -25,6 +25,11 @@ func (d *DatabasesClient) List() ([]Database, error) {
 	}
 	defer r.Body.Close()
 
+	org := d.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
 	if r.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get database listing: %s", r.Status)
 	}
@@ -43,6 +48,11 @@ func (d *DatabasesClient) Delete(database string) error {
 		return fmt.Errorf("failed to delete database: %s", err)
 	}
 	defer r.Body.Close()
+
+	org := d.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
 
 	if r.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(database), internal.Emph("turso db list"))
@@ -74,6 +84,11 @@ func (d *DatabasesClient) Create(name, region, image string) (*CreateDatabaseRes
 	}
 	defer res.Body.Close()
 
+	org := d.client.org
+	if isNotMemberErr(res.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
 	if res.StatusCode == http.StatusUnprocessableEntity {
 		return nil, fmt.Errorf("database name '%s' is not available", name)
 	}
@@ -98,6 +113,11 @@ func (d *DatabasesClient) Seed(name string, dbFile *os.File) error {
 	}
 	defer res.Body.Close()
 
+	org := d.client.org
+	if isNotMemberErr(res.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
 	if res.StatusCode == http.StatusUnprocessableEntity {
 		return fmt.Errorf("database name '%s' is not available", name)
 	}
@@ -120,6 +140,11 @@ func (d *DatabasesClient) ChangePassword(database string, newPassword string) er
 		return fmt.Errorf("failed to change database password: %s", err)
 	}
 	defer r.Body.Close()
+
+	org := d.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
 
 	if r.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(database), internal.Emph("turso db list"))
@@ -144,6 +169,11 @@ func (d *DatabasesClient) Token(database string, expiration string, readOnly boo
 	}
 	defer r.Body.Close()
 
+	org := d.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return "", notMemberErr(org)
+	}
+
 	if r.StatusCode != http.StatusOK {
 		err, _ := unmarshal[string](r)
 		return "", fmt.Errorf("failed to get database token: %d %s", r.StatusCode, err)
@@ -165,6 +195,11 @@ func (d *DatabasesClient) Rotate(database string) error {
 	}
 	defer r.Body.Close()
 
+	org := d.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
 	if r.StatusCode != http.StatusOK {
 		err, _ := unmarshal[string](r)
 		return fmt.Errorf("failed to rotate database keys: %d %s", r.StatusCode, err)
@@ -180,6 +215,11 @@ func (d *DatabasesClient) Update(database string) error {
 		return fmt.Errorf("failed to update database: %w", err)
 	}
 	defer r.Body.Close()
+
+	org := d.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
 
 	if r.StatusCode != http.StatusOK {
 		err, _ := unmarshal[string](r)

--- a/internal/turso/instances.go
+++ b/internal/turso/instances.go
@@ -23,6 +23,11 @@ func (i *InstancesClient) List(db string) ([]Instance, error) {
 	}
 	defer r.Body.Close()
 
+	org := i.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
+
 	if r.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("response with status code %d", r.StatusCode)
 	}
@@ -43,6 +48,11 @@ func (i *InstancesClient) Delete(db, instance string) error {
 		return fmt.Errorf("failed to destroy instances %s of %s: %s", instance, db, err)
 	}
 	defer r.Body.Close()
+
+	org := i.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
 
 	if r.StatusCode == http.StatusBadRequest {
 		body, _ := unmarshal[struct{ Error string }](r)
@@ -77,6 +87,11 @@ func (d *InstancesClient) Create(dbName, instanceName, password, region, image s
 		return nil, fmt.Errorf("failed to create new instances for %s: %s", dbName, err)
 	}
 	defer res.Body.Close()
+
+	org := d.client.org
+	if isNotMemberErr(res.StatusCode, org) {
+		return nil, notMemberErr(org)
+	}
 
 	if res.StatusCode != http.StatusOK {
 		return nil, parseResponseError(res)

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -68,19 +68,16 @@ func (c *OrganizationsClient) Delete(slug string) error {
 		return fmt.Errorf("could not find organization %s", slug)
 	}
 
-	if r.StatusCode == http.StatusBadRequest {
+	switch r.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusBadRequest:
 		return fmt.Errorf("cannot delete personal organization %s", slug)
-	}
-
-	if r.StatusCode == http.StatusUnauthorized {
+	case http.StatusForbidden:
 		return fmt.Errorf("you do not have permission to delete organization %s", slug)
-	}
-
-	if r.StatusCode != http.StatusOK {
+	default:
 		return fmt.Errorf("failed to delete organization: %s", r.Status)
 	}
-
-	return nil
 }
 
 type Member struct {

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -100,6 +100,10 @@ func (c *OrganizationsClient) ListMembers() ([]Member, error) {
 	}
 	defer r.Body.Close()
 
+	if r.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("only organization owners can list members")
+	}
+
 	if r.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to list organization members: %s", r.Status)
 	}
@@ -129,6 +133,10 @@ func (c *OrganizationsClient) AddMember(username string) error {
 	}
 	defer r.Body.Close()
 
+	if r.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("only organization owners can add members")
+	}
+
 	if r.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to add organization member: %s", r.Status)
 	}
@@ -147,6 +155,10 @@ func (c *OrganizationsClient) RemoveMember(username string) error {
 		return fmt.Errorf("failed to delete organization member: %s", err)
 	}
 	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("only organization owners can remove members")
+	}
 
 	if r.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to remove organization member: %s", r.Status)


### PR DESCRIPTION
Makes two improvements:
- When the user tries to manage members of orgs they aren't the owner, we tell them that it can't happen.
- When the user has an org configured to which they aren't members, we tell them that and set them back to personal org.