### PR TITLE
Speedup db inspect

### DIFF
--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -194,7 +194,7 @@ func inspectStorage(url, token string, detailed bool, location string) (*Storage
 	}
 
 	if respType.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error: %s", string(body))
+		return nil, fmt.Errorf("error: %s", string(bodyType))
 	}
 
 	var results []QueryResult


### PR DESCRIPTION
Currently db inspect can get really slow if replicas are far away from the client.
This PR reduced the time db inspect takes for the following db from 8s to below 3s:
```
Locations:      arn, fra, gru, iad, waw, yyz
```
For a db that has instances in every possible location this PR speeds up db inspect from over 20s to 2-3s.

Calling instances in parallel can be especially beneficial when those instances are scaled down because waking an instance up is particularly slow.