### PR TITLE
Add timeout to db inspect

### DIFF
--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
@@ -51,7 +52,7 @@ var accountShowCmd = &cobra.Command{
 
 			for _, instance := range instances {
 				url := getInstanceHttpUrl(settings, &database, &instance)
-				ret, err := inspect(url, token, instance.Region, false)
+				ret, err := inspect(context.Background(), url, token, instance.Region, false)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -389,6 +390,10 @@ func query(url, token, stmt string) error {
 }
 
 func doQuery(url, token, stmt string) (*http.Response, error) {
+	return doQueryContext(context.Background(), url, token, stmt)
+}
+
+func doQueryContext(ctx context.Context, url, token, stmt string) (*http.Response, error) {
 	stmts, err := sqlparser.SplitStatementToPieces(stmt)
 	if err != nil {
 		return nil, err
@@ -400,7 +405,7 @@ func doQuery(url, token, stmt string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I have an old db for which db inspect hangs for ever.
Reaction to Ctrl-C has a big delay and the overall experience
is pretty bad.

With this change db inspect times out after 30s and
prints a meaningful error.

This PR has just one commit and depends on https://github.com/chiselstrike/turso-cli/pull/379