### PR TITLE
Use tokens with the shortest possible expiration

### DIFF
--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -44,7 +44,7 @@ var accountShowCmd = &cobra.Command{
 				return err
 			}
 
-			token, err := client.Databases.Token(database.Name, "default", true)
+			token, err := client.Databases.Token(database.Name, "1d", true)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -79,7 +79,7 @@ var dbInspectCmd = &cobra.Command{
 			return err
 		}
 
-		token, err := client.Databases.Token(db.Name, "default", true)
+		token, err := client.Databases.Token(db.Name, "1d", true)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -185,7 +185,7 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 		return "", nil
 	}
 
-	return client.Databases.Token(db.Name, "default", false)
+	return client.Databases.Token(db.Name, "1d", false)
 }
 
 func printConnectionInfo(nameOrUrl string, db *turso.Database, config *settings.Settings) {


### PR DESCRIPTION
Since #357 default expiration is never.
We use db tokens for a very short operations
so we should limit their lifetime to the shortest
possible which currently is 1 day.