### PR TITLE
feat: add turso quickstart homebrew post install

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,11 +64,7 @@ brews:
       zsh_completion.install "completions/turso.zsh" => "_turso"
       fish_completion.install "completions/turso.fish"
     post_install: |
-      puts "Turso CLI installed!"
-      puts ""
-      puts "If you are a new user, you can sign up with `turso auth signup`."
-      puts ""
-      puts "If you already have an account, please login with `turso auth login`."
+      exec('turso quickstart')
 
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.


### PR DESCRIPTION
This PR aims to add `turso quickstart` to homebrew post install command.