### PR TITLE
feat: hide instance urls by default on db show command

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -14,6 +14,7 @@ import (
 var showUrlFlag bool
 var showBasicAuthFlag bool
 var showHttpUrlFlag bool
+var showInstanceUrlsFlag bool
 var showInstanceUrlFlag string
 var passwordFlag string
 var yesFlag bool

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"io"
 	"net/http"
 	"net/url"
@@ -11,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
@@ -21,6 +22,7 @@ func init() {
 	dbCmd.AddCommand(showCmd)
 	showCmd.Flags().BoolVar(&showUrlFlag, "url", false, "Show URL for the database HTTP API.")
 	showCmd.Flags().BoolVar(&showBasicAuthFlag, "basic-auth", false, "Show basic authentication in the URL.")
+	showCmd.Flags().BoolVar(&showInstanceUrlsFlag, "instance-urls", false, "Show URL for the HTTP API of all existing instances")
 	showCmd.Flags().StringVar(&showInstanceUrlFlag, "instance-url", "", "Show URL for the HTTP API of a selected instance of a database. Instance is selected by instance name.")
 	showCmd.RegisterFlagCompletionFunc("instance-url", completeInstanceName)
 	showCmd.RegisterFlagCompletionFunc("instance-ws-url", completeInstanceName)
@@ -89,7 +91,11 @@ var showCmd = &cobra.Command{
 		data := [][]string{}
 		for idx, instance := range instances {
 			version := <-versions[idx]
-			data = append(data, []string{instance.Name, instance.Type, instance.Region, version, urls[idx]})
+			if showInstanceUrlsFlag {
+				data = append(data, []string{instance.Name, instance.Type, instance.Region, version, urls[idx]})
+			} else {
+				data = append(data, []string{instance.Name, instance.Type, instance.Region, version})
+			}
 		}
 
 		fmt.Println("Name:          ", db.Name)
@@ -98,7 +104,11 @@ var showCmd = &cobra.Command{
 		fmt.Println("Locations:     ", strings.Join(regions, ", "))
 		fmt.Println()
 		fmt.Print("Database Instances:\n")
-		printTable([]string{"Name", "Type", "Location", "Version", "URL"}, data)
+		if showInstanceUrlsFlag {
+			printTable([]string{"Name", "Type", "Location", "Version", "URL"}, data)
+		} else {
+			printTable([]string{"Name", "Type", "Location", "Version"}, data)
+		}
 
 		return nil
 	},

--- a/testing/database_test.go
+++ b/testing/database_test.go
@@ -102,7 +102,7 @@ func createReplica(c *qt.C, dbName string, configPath *string, replicaName strin
 }
 
 func runSqlOnPrimaryAndReplica(c *qt.C, dbName string, configPath *string, tablePrefix string, replicaName string) {
-	output, err := turso(configPath, "db", "show", dbName)
+	output, err := turso(configPath, "db", "show", dbName, "--instance-urls")
 	c.Assert(err, qt.IsNil, qt.Commentf(output))
 	c.Assert(output, qt.Contains, "Locations:      ams, waw")
 	c.Assert(output, qt.Contains, "primary     waw")


### PR DESCRIPTION
This PR aims to add a flag to hide the instance URLs by default on `db show` command

closes #362