### PR TITLE
Improve DB creation from local sqlite file

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -17,6 +17,7 @@ func init() {
 	addCanaryFlag(createCmd)
 	addDbFromFileFlag(createCmd)
 	addLocationFlag(createCmd, "Location ID. If no ID is specified, closest location to you is used by default.")
+	addWaitFlag(createCmd, "Wait for the database to be ready to receive requests.")
 }
 
 var createCmd = &cobra.Command{
@@ -104,7 +105,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		if dbFile != nil {
+		if waitFlag || dbFile != nil {
 			description = fmt.Sprintf("Waiting for database %s to be ready", internal.Emph(name))
 			spinner.Text(description)
 			if err = client.Instances.Wait(name, instance.Name); err != nil {

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -95,12 +95,21 @@ var createCmd = &cobra.Command{
 				return fmt.Errorf("could not create database %s: %w", name, err)
 			}
 
-			description = fmt.Sprintf("Finishing creating database %s%s in %s ", internal.Emph(name), dbText, internal.Emph(regionText))
+			description = fmt.Sprintf("Finishing to create database %s%s in %s ", internal.Emph(name), dbText, internal.Emph(regionText))
 			spinner.Text(description)
 		}
 
-		if _, err = client.Instances.Create(name, "", region, image); err != nil {
+		instance, err := client.Instances.Create(name, "", region, image)
+		if err != nil {
 			return err
+		}
+
+		if dbFile != nil {
+			description = fmt.Sprintf("Waiting for database %s to be ready", internal.Emph(name))
+			spinner.Text(description)
+			if err = client.Instances.Wait(name, instance.Name); err != nil {
+				return err
+			}
 		}
 
 		spinner.Stop()

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -71,8 +71,8 @@ var createCmd = &cobra.Command{
 		}
 
 		description := fmt.Sprintf("Creating database %s%s in %s ", internal.Emph(name), dbText, internal.Emph(regionText))
-		bar := prompt.Spinner(description)
-		defer bar.Stop()
+		spinner := prompt.Spinner(description)
+		defer spinner.Stop()
 
 		res, err := client.Databases.Create(name, region, image)
 		if err != nil {
@@ -86,18 +86,24 @@ var createCmd = &cobra.Command{
 
 		if dbFile != nil {
 			defer dbFile.Close()
+			description = fmt.Sprintf("Uploading database file %s", internal.Emph(fromFileFlag))
+			spinner.Text(description)
+
 			err := client.Databases.Seed(name, dbFile)
 			if err != nil {
 				client.Databases.Delete(name)
 				return fmt.Errorf("could not create database %s: %w", name, err)
 			}
+
+			description = fmt.Sprintf("Finishing creating database %s%s in %s ", internal.Emph(name), dbText, internal.Emph(regionText))
+			spinner.Text(description)
 		}
 
 		if _, err = client.Instances.Create(name, "", region, image); err != nil {
 			return err
 		}
 
-		bar.Stop()
+		spinner.Stop()
 		elapsed := time.Since(start)
 		fmt.Printf("Created database %s in %s in %d seconds.\n\n", internal.Emph(name), internal.Emph(regionText), int(elapsed.Seconds()))
 

--- a/internal/cmd/wait_flag.go
+++ b/internal/cmd/wait_flag.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var waitFlag bool
+
+func addWaitFlag(cmd *cobra.Command, desc string) {
+	cmd.Flags().BoolVarP(&waitFlag, "wait", "w", false, desc)
+}

--- a/internal/prompt/spinner.go
+++ b/internal/prompt/spinner.go
@@ -60,6 +60,10 @@ func (m *spinner) Stop() {
 	<-m.done
 }
 
+func (m *spinner) Text(t string) {
+	m.suffix = t
+}
+
 func (m *spinner) Start() {
 	go func() {
 		tea.NewProgram(m).Run()

--- a/internal/turso/instances.go
+++ b/internal/turso/instances.go
@@ -105,6 +105,36 @@ func (d *InstancesClient) Create(dbName, instanceName, region, image string) (*I
 	return &data.Instance, nil
 }
 
+func (i *InstancesClient) Wait(db, instance string) error {
+	url := i.URL(db, instance+"/wait")
+	r, err := i.client.Get(url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to wait for instance %s to of %s be ready: %s", instance, db, err)
+	}
+	defer r.Body.Close()
+
+	org := i.client.org
+	if isNotMemberErr(r.StatusCode, org) {
+		return notMemberErr(org)
+	}
+
+	if r.StatusCode == http.StatusBadRequest {
+		body, _ := unmarshal[struct{ Error string }](r)
+		return errors.New(body.Error)
+	}
+
+	if r.StatusCode == http.StatusNotFound {
+		body, _ := unmarshal[struct{ Error string }](r)
+		return errors.New(body.Error)
+	}
+
+	if r.StatusCode != http.StatusOK {
+		return fmt.Errorf("response with status code %d", r.StatusCode)
+	}
+
+	return nil
+}
+
 func (d *InstancesClient) URL(database, suffix string) string {
 	prefix := "/v1"
 	if d.client.org != "" {

--- a/internal/turso/instances.go
+++ b/internal/turso/instances.go
@@ -42,7 +42,7 @@ func (i *InstancesClient) List(db string) ([]Instance, error) {
 }
 
 func (i *InstancesClient) Delete(db, instance string) error {
-	url := i.URL(db, instance)
+	url := i.URL(db, "/"+instance)
 	r, err := i.client.Delete(url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to destroy instances %s of %s: %s", instance, db, err)
@@ -106,7 +106,7 @@ func (d *InstancesClient) Create(dbName, instanceName, region, image string) (*I
 }
 
 func (i *InstancesClient) Wait(db, instance string) error {
-	url := i.URL(db, instance+"/wait")
+	url := i.URL(db, "/"+instance+"/wait")
 	r, err := i.client.Get(url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to wait for instance %s to of %s be ready: %s", instance, db, err)
@@ -140,5 +140,5 @@ func (d *InstancesClient) URL(database, suffix string) string {
 	if d.client.org != "" {
 		prefix = "/v1/organizations/" + d.client.org
 	}
-	return fmt.Sprintf("%s/databases/%s/instances/%s", prefix, database, suffix)
+	return fmt.Sprintf("%s/databases/%s/instances%s", prefix, database, suffix)
 }


### PR DESCRIPTION
Changes the spinner to inform which task the `turso db create` command currently is doing.
Waits for the database to load the seed, which can take a while as well. 

Also adds a `--wait` or `-w` flag to both `turso db create` and `turso db replicate`, which makes the command wait until the new instance is ready to receive requests.

---

Example of creating a database with a local SQlite file of 43MB:

https://user-images.githubusercontent.com/7853668/236575684-676500cb-ab05-46b2-8cfd-75392c3bebbf.mov

---

How to generate a similar file locally:
```bash
echo "CREATE TABLE blobs (blob BLOB NOT NULL);" > dump.sql
for i in {1..1000}; do echo "INSERT INTO t VALUES (zeroblob(32768));" >> dump.sql; done;
sqlite3 db.sqlite < dump.sql
```
Then just:
```bash
turso db create --from-file db.sqlite
```