### PR TITLE
Remove DatabaseSettings

### DIFF
--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -71,15 +71,8 @@ var createCmd = &cobra.Command{
 		spinner := prompt.Spinner(description)
 		defer spinner.Stop()
 
-		res, err := client.Databases.Create(name, region, image)
-		if err != nil {
+		if _, err := client.Databases.Create(name, region, image); err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)
-		}
-
-		dbSettings := settings.DatabaseSettings{
-			Name:     res.Database.Name,
-			Username: res.Username,
-			Password: res.Password,
 		}
 
 		if dbFile != nil {
@@ -118,7 +111,7 @@ var createCmd = &cobra.Command{
 		fmt.Printf("   turso db shell %s\n\n", name)
 		fmt.Printf("To see information about the database, including a connection URL, run:\n\n")
 		fmt.Printf("   turso db show %s\n\n", name)
-		config.AddDatabase(res.Database.ID, &dbSettings)
+
 		config.InvalidateDbNamesCache()
 
 		firstTime := config.RegisterUse("db_create")

--- a/internal/cmd/db_passwd.go
+++ b/internal/cmd/db_passwd.go
@@ -5,7 +5,6 @@ import (
 	"syscall"
 
 	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
-	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -30,15 +29,6 @@ var changePasswordCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		db, err := getDatabase(client, args[0])
-		if err != nil {
-			return err
-		}
-
-		config, err := settings.ReadSettings()
-		if err != nil {
-			return err
-		}
 
 		var newPassword string
 		if len(passwordFlag) > 0 {
@@ -59,10 +49,7 @@ var changePasswordCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = config.SetDatabasePassword(db.ID, newPassword)
-		if err != nil {
-			return fmt.Errorf("password changed but failed to persist in locally. Please retry. Error: %s", err)
-		}
+
 		fmt.Println("Password changed succesfully!")
 		return nil
 	},

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -113,16 +113,13 @@ var showCmd = &cobra.Command{
 }
 
 func fetchInstanceVersion(client *turso.Client, config *settings.Settings, db *turso.Database, instance *turso.Instance) string {
-	baseUrl := getInstanceHttpUrlWithoutAuth(config, db, instance)
+	baseUrl := getInstanceHttpUrl(config, db, instance)
 
 	token, err := tokenFromDb(db, client)
 	if err != nil {
 		return fmt.Sprintf("fetch failed: %s", err)
 	}
 
-	if token == "" {
-		baseUrl = getInstanceHttpUrl(config, db, instance)
-	}
 	url, err := url.Parse(baseUrl)
 	if err != nil {
 		return fmt.Sprintf("fetch failed: %s", err)

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -72,43 +72,27 @@ func extractPrimary(instances []turso.Instance) (primary *turso.Instance, others
 }
 
 func getDatabaseUrl(settings *settings.Settings, db *turso.Database, password bool) string {
-	return getUrl(settings, db, nil, "libsql", password)
+	return getUrl(settings, db, nil, "libsql")
 }
 
 func getInstanceUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance) string {
-	return getUrl(settings, db, inst, "libsql", false)
+	return getUrl(settings, db, inst, "libsql")
 }
 
 func getDatabaseHttpUrl(settings *settings.Settings, db *turso.Database) string {
-	return getUrl(settings, db, nil, "https", true)
+	return getUrl(settings, db, nil, "https")
 }
 
 func getInstanceHttpUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance) string {
-	return getUrl(settings, db, inst, "https", true)
+	return getUrl(settings, db, inst, "https")
 }
 
-func getInstanceHttpUrlWithoutAuth(settings *settings.Settings, db *turso.Database, inst *turso.Instance) string {
-	return getUrl(settings, db, inst, "https", false)
-}
-
-func getUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance, scheme string, password bool) string {
-	dbSettings := settings.GetDatabaseSettings(db.ID)
-	if dbSettings == nil {
-		// Backwards compatibility with old settings files.
-		dbSettings = settings.GetDatabaseSettings(db.Name)
-	}
-
+func getUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance, scheme string) string {
 	host := db.Hostname
 	if inst != nil {
 		host = inst.Hostname
 	}
-
-	user := ""
-	if password && dbSettings != nil {
-		user = fmt.Sprintf("%s:%s@", dbSettings.Username, dbSettings.Password)
-	}
-
-	return fmt.Sprintf("%s://%s%s", scheme, user, host)
+	return fmt.Sprintf("%s://%s", scheme, host)
 }
 
 func getDatabaseRegions(db turso.Database) string {
@@ -159,7 +143,6 @@ func destroyDatabase(client *turso.Client, name string) error {
 		settings.InvalidateDbNamesCache()
 	}
 
-	settings.DeleteDatabase(name)
 	return nil
 }
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,18 +1,9 @@
 package settings
 
 import (
-	"errors"
-
 	"github.com/kirsle/configdir"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 )
-
-type DatabaseSettings struct {
-	Name     string `json:"name"`
-	Username string `json:"username"`
-	Password string `json:"Password"`
-}
 
 type Settings struct {
 	changed bool
@@ -60,13 +51,6 @@ func PersistChanges() {
 	}
 }
 
-func (s *Settings) AddDatabase(id string, dbSettings *DatabaseSettings) {
-	databases := viper.GetStringMap("databases")
-	databases[id] = dbSettings
-	viper.Set("databases", databases)
-	s.changed = true
-}
-
 func (s *Settings) RegisterUse(cmd string) bool {
 	commands := viper.GetStringMap("usedCommands")
 	firstTime := true
@@ -86,44 +70,6 @@ func (s *Settings) SetOrganization(org string) {
 
 func (s *Settings) Organization() string {
 	return viper.GetString("organization")
-}
-
-func (s *Settings) DeleteDatabase(name string) {
-	databases := viper.GetStringMap("databases")
-	for id, rawSettings := range databases {
-		settings := DatabaseSettings{}
-		mapstructure.Decode(rawSettings, &settings)
-		if settings.Name == name {
-			delete(databases, id)
-			s.changed = true
-		}
-	}
-}
-
-func (s *Settings) GetDatabaseSettings(id string) *DatabaseSettings {
-	databases := viper.GetStringMap("databases")
-	rawSettings, ok := databases[id]
-	if !ok {
-		return nil
-	}
-	settings := DatabaseSettings{}
-	mapstructure.Decode(rawSettings, &settings)
-	return &settings
-}
-
-func (s *Settings) SetDatabasePassword(id string, password string) error {
-	databases := viper.GetStringMap("databases")
-	rawSettings, ok := databases[id]
-	if !ok {
-		return errors.New("database not found")
-	}
-	settings := DatabaseSettings{}
-	mapstructure.Decode(rawSettings, &settings)
-	settings.Password = password
-	databases[id] = settings
-	viper.Set("databases", databases)
-	s.changed = true
-	return nil
 }
 
 func (s *Settings) SetToken(token string) {


### PR DESCRIPTION
Even though it gave us a slick experience in the beginning, storing database metadata locally is a stopper because it is bound to a single device.
Since we're using database tokens for all DB operations, we can safely drop `DatabaseSettings` for the settings file.
