### PR TITLE
feat: show user plan and limits on account show

### DIFF
--- a/internal/cmd/account.go
+++ b/internal/cmd/account.go
@@ -1,6 +1,43 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+)
+
+type PlanInfo struct {
+	maxDatabases uint64
+	maxStorage   uint64
+	maxLocations uint64
+}
+
+type PlanType string
+
+const (
+	ENTERPRISE PlanType = "enterprise"
+	SCALER     PlanType = "scaler"
+	STARTER    PlanType = "starter"
+)
+
+var planInfos = map[PlanType]PlanInfo{
+	STARTER: {
+		maxDatabases: 3,
+		maxLocations: 3,
+		maxStorage:   8,
+	},
+	SCALER: {
+		maxDatabases: 6,
+		maxLocations: 6,
+		maxStorage:   20,
+	},
+	ENTERPRISE: {
+		maxDatabases: 0,
+		maxLocations: 0,
+		maxStorage:   0,
+	},
+}
 
 var accountCmd = &cobra.Command{
 	Use:   "account",
@@ -12,4 +49,30 @@ func init() {
 	accountCmd.AddCommand(accountShowCmd)
 	accountCmd.AddCommand(accountBookMeetingCmd)
 	accountCmd.AddCommand(accountFeedbackCmd)
+}
+
+type FormattedPlanInfo struct {
+	maxDatabases string
+	maxStorage   string
+	maxLocation  string
+}
+
+func getPlanInfo(plan PlanType) FormattedPlanInfo {
+	planInfo := planInfos[plan]
+
+	maxStorage := "Unlimited"
+	maxDatabases := "Unlimited"
+	maxLocation := "Unlimited"
+
+	if plan != ENTERPRISE {
+		maxStorage = fmt.Sprint(humanize.IBytes(planInfo.maxStorage * 1024 * 1024 * 1024))
+		maxDatabases = fmt.Sprint(planInfo.maxDatabases)
+		maxLocation = fmt.Sprint(planInfo.maxLocations)
+	}
+
+	return FormattedPlanInfo{
+		maxStorage:   maxStorage,
+		maxDatabases: maxDatabases,
+		maxLocation:  maxLocation,
+	}
 }

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -27,6 +27,7 @@ type Client struct {
 	ApiTokens     *ApiTokensClient
 	Locations     *LocationsClient
 	Tokens        *TokensClient
+	Users         *UsersClient
 }
 
 // Client struct that will be aliases by all other clients
@@ -45,6 +46,7 @@ func New(base *url.URL, token string, cliVersion string, org string) *Client {
 	c.ApiTokens = (*ApiTokensClient)(c.base)
 	c.Locations = (*LocationsClient)(c.base)
 	c.Tokens = (*TokensClient)(c.base)
+	c.Users = (*UsersClient)(c.base)
 	return c
 }
 

--- a/internal/turso/users.go
+++ b/internal/turso/users.go
@@ -1,0 +1,36 @@
+package turso
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type UsersClient client
+
+type UserInfo struct {
+	Username string `json:"username"`
+	Plan     string `json:"plan"`
+}
+
+type UserInfoResponse struct {
+	User UserInfo `json:"user"`
+}
+
+func (u *UsersClient) GetUser() (UserInfo, error) {
+	res, err := u.client.Get("/v1/current-user", nil)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("failed to get user info: %s", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return UserInfo{}, parseResponseError(res)
+	}
+
+	data, err := unmarshal[UserInfoResponse](res)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("failed to deserialize response: %w", err)
+	}
+
+	return data.User, nil
+}


### PR DESCRIPTION
This PR aims to update `turso account show` command to use the data from API to show the account plan and limits

closes #334