### PR TITLE
fix: add validation to avoid api tokens/databases creation with invalid name

### DIFF
--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +30,12 @@ var createApiTokensCmd = &cobra.Command{
 			return err
 		}
 
-		tokenName := args[0]
+		tokenName := strings.TrimSpace(args[0])
+
+		if !turso.IsValidName(tokenName) {
+			return errors.New("invalid name: names only support lowercase letters, numbers, and hyphens")
+		}
+
 		description := fmt.Sprintf("Creating api token %s", internal.Emph(tokenName))
 		bar := prompt.Spinner(description)
 		defer bar.Stop()

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +32,10 @@ var createCmd = &cobra.Command{
 		name, err := getDatabaseName(args)
 		if err != nil {
 			return err
+		}
+
+		if !turso.IsValidName(name) {
+			return errors.New("invalid name: names only support lowercase letters, numbers, and hyphens")
 		}
 
 		config, err := settings.ReadSettings()

--- a/internal/turso/utils.go
+++ b/internal/turso/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"unicode"
 )
 
 func unmarshal[T any](r *http.Response) (T, error) {
@@ -30,4 +31,13 @@ func parseResponseError(res *http.Response) error {
 		return fmt.Errorf("%s", result.Error)
 	}
 	return fmt.Errorf("response failed with status %s", res.Status)
+}
+
+func IsValidName(name string) bool {
+	for _, r := range name {
+		if !(unicode.IsDigit(r) || (unicode.IsLetter(r) && unicode.IsLower(r)) || r == '-') {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This PR aims to add a validation to avoid API tokens creation with an invalid name.

closes #403 