### PR TITLE
fix: abort auth commands when token is set in env

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -26,6 +26,7 @@ var authCmd = &cobra.Command{
 	Use:               "auth",
 	Short:             "Authenticate with Turso",
 	ValidArgsFunction: noSpaceArg,
+	PersistentPreRunE: verifyIfTokenIsSetInEnv,
 }
 
 var signupCmd = &cobra.Command{
@@ -284,6 +285,16 @@ func logout(cmd *cobra.Command, args []string) error {
 		settings.SetToken("")
 		settings.SetUsername("")
 		fmt.Println("Logged out.")
+	}
+
+	return nil
+}
+
+func verifyIfTokenIsSetInEnv(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	envToken := os.Getenv(ENV_ACCESS_TOKEN)
+	if envToken != "" {
+		return fmt.Errorf("auth commands aren't effective when a token is set in the environment variable")
 	}
 
 	return nil

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -106,9 +106,8 @@ func getAccessToken(warnMultipleAccessTokenSources bool) (string, error) {
 		return "", fmt.Errorf("could not read local settings")
 	}
 	settingsToken := settings.GetToken()
-
 	if !viper.GetBool("no-multiple-token-sources-warning") && envToken != "" && settingsToken != "" && warnMultipleAccessTokenSources {
-		fmt.Printf("Warning: User logged in as %s but TURSO_API_TOKEN environment variable is set so proceeding to use it instead", settings.GetUsername())
+		fmt.Printf("Warning: User logged in as %s but TURSO_API_TOKEN environment variable is set so proceeding to use it instead\n\n", settings.GetUsername())
 	}
 	if envToken != "" {
 		return envToken, nil


### PR DESCRIPTION
This PR aims to make all `auth` commands fail if the token is set in env.

closes #270 