### PR TITLE
refactor: change the create api-tokens command to mint

### DIFF
--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -16,10 +16,10 @@ func init() {
 }
 
 var createApiTokensCmd = &cobra.Command{
-	Use:   "create api_token_name",
-	Short: "Create an API token.",
+	Use:   "mint api_token_name",
+	Short: "Mint an API token.",
 	Long: "" +
-		"API tokens are revocable non-expiring tokens that authenticate holders as the user who created them.\n" +
+		"API tokens are revocable non-expiring tokens that authenticate holders as the user who minted them.\n" +
 		"They can be used to implement automations with the " + internal.Emph("turso") + " CLI or the platform API.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/auth_listapitokens.go
+++ b/internal/cmd/auth_listapitokens.go
@@ -13,7 +13,7 @@ var listApiTokensCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List API tokens.",
 	Long: "" +
-		"API tokens are revocable non-expiring tokens that authenticate holders as the user who created them.\n" +
+		"API tokens are revocable non-expiring tokens that authenticate holders as the user who minted them.\n" +
 		"They can be used to implement automations with the " + internal.Emph("turso") + " CLI or the platform API.",
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR aims to refactor the `turso auth api-tokens create` to `turso auth api-tokens mint`.

closes #404 