### PR TITLE
Fix db hostname not found in shell cmd

### DIFF
--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -150,7 +150,7 @@ func databaseFromURL(dbURL string, client *turso.Client) (*turso.Database, error
 		}
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("hostname '%s' not found", parsed.Hostname())
 }
 
 func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {


### PR DESCRIPTION
#401 

Have returned an error statement when the function is not able to find the hostname in the list of DBs. 

Let me know if this is a valid fix or if any further changes are required.
Thank you.