### PR TITLE
call sqld instead

### DIFF
--- a/internal/cmd/dev_file.go
+++ b/internal/cmd/dev_file.go
@@ -5,5 +5,5 @@ import "github.com/spf13/cobra"
 var devFile string
 
 func addDevFileFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&devFile, "local-file", "", "A file name to persist the data of this dev session")
+	cmd.Flags().StringVarP(&devFile, "db-file", "f", "", "A file name to persist the data of this dev session")
 }

--- a/internal/cmd/dev_port_flag.go
+++ b/internal/cmd/dev_port_flag.go
@@ -5,5 +5,5 @@ import "github.com/spf13/cobra"
 var devPort int
 
 func addDevPortFlag(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&devPort, "port", 3030, "the port to which bind the server")
+	cmd.Flags().IntVarP(&devPort, "port", "p", 8080, "the port to which bind the server")
 }


### PR DESCRIPTION
This PR calls sqld instead of trying to implement hrana in go.

It puts the burden on the user to install it, but as soon as we start publishing binaries we can download it ourselves.