### PR TITLE
Add --from-file flag to turso db shell

### DIFF
--- a/internal/cmd/auth_createapitokens.go
+++ b/internal/cmd/auth_createapitokens.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
@@ -37,7 +37,7 @@ var createApiTokensCmd = &cobra.Command{
 		}
 
 		description := fmt.Sprintf("Creating api token %s", internal.Emph(tokenName))
-		bar := prompt.Spinner(description)
+		bar := spinner.Start(description)
 		defer bar.Stop()
 
 		data, err := client.ApiTokens.Create(tokenName)

--- a/internal/cmd/auth_revokeapitokens.go
+++ b/internal/cmd/auth_revokeapitokens.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ var revokeApiTokensCmd = &cobra.Command{
 			return nil
 		}
 
-		s := prompt.Spinner(fmt.Sprintf("Revoking API token %s... ", internal.Emph(tokenName)))
+		s := spinner.Start(fmt.Sprintf("Revoking API token %s... ", internal.Emph(tokenName)))
 		defer s.Stop()
 
 		if err := client.ApiTokens.Revoke(tokenName); err != nil {

--- a/internal/cmd/batch_flag.go
+++ b/internal/cmd/batch_flag.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var batchFlag int
+
+func addBatchFlag(cmd *cobra.Command, usage string) {
+	cmd.Flags().IntVar(&batchFlag, "batch", 1000, usage)
+}

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/athoscouto/codename"
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
@@ -74,7 +74,7 @@ var createCmd = &cobra.Command{
 
 		start := time.Now()
 		description := fmt.Sprintf("Creating database %s%s in %s ", internal.Emph(name), dbText, internal.Emph(regionText))
-		spinner := prompt.Spinner(description)
+		spinner := spinner.Start(description)
 		defer spinner.Stop()
 
 		if _, err := client.Databases.Create(name, region, image); err != nil {

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -145,8 +145,8 @@ func getDbFile(path string) (*os.File, error) {
 		return nil, fmt.Errorf("can't stat %s: %w", fromFileFlag, err)
 	}
 
-	if stat.Size() > (2 << 30) {
-		return nil, fmt.Errorf("only files up to 2GiB are supported")
+	if stat.Size() > 100*(1<<20) {
+		return nil, fmt.Errorf("only files up to 100MiB are supported")
 	}
 
 	valid, err := isSQLiteFile(f)

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -17,7 +17,7 @@ import (
 func init() {
 	dbCmd.AddCommand(createCmd)
 	addCanaryFlag(createCmd)
-	addDbFromFileFlag(createCmd)
+	addFromFileFlag(createCmd, "create the database from a local SQLite3-compatible file")
 	addLocationFlag(createCmd, "Location ID. If no ID is specified, closest location to you is used by default.")
 	addWaitFlag(createCmd, "Wait for the database to be ready to receive requests.")
 }

--- a/internal/cmd/db_invalidatetokens.go
+++ b/internal/cmd/db_invalidatetokens.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
@@ -54,7 +54,7 @@ var dbInvalidateTokensCmd = &cobra.Command{
 }
 
 func rotate(turso *turso.Client, name string) error {
-	s := prompt.Spinner("Invalidating db auth tokens... ")
+	s := spinner.Start("Invalidating db auth tokens... ")
 	defer s.Stop()
 
 	if err := turso.Databases.Rotate(name); err != nil {

--- a/internal/cmd/db_passwd.go
+++ b/internal/cmd/db_passwd.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -42,7 +42,7 @@ var changePasswordCmd = &cobra.Command{
 			newPassword = string(bytePassword)
 		}
 
-		bar := prompt.Spinner("Changing password...")
+		bar := spinner.Start("Changing password...")
 		defer bar.Stop()
 
 		err = client.Databases.ChangePassword(args[0], newPassword)

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
@@ -72,7 +72,7 @@ var replicateCmd = &cobra.Command{
 		}
 
 		regionText := fmt.Sprintf("%s (%s)", locationDescription(client, region), region)
-		s := prompt.Spinner(fmt.Sprintf("Replicating database %s to %s ", internal.Emph(dbName), internal.Emph(regionText)))
+		s := spinner.Start(fmt.Sprintf("Replicating database %s to %s ", internal.Emph(dbName), internal.Emph(regionText)))
 		defer s.Stop()
 
 		start := time.Now()

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/libsql/libsql-shell-go/pkg/shell"
@@ -32,7 +32,7 @@ var shellCmd = &cobra.Command{
 		}
 		cmd.SilenceUsage = true
 
-		spinner := prompt.StoppedSpinner("Connecting to database")
+		spinner := spinner.New("Connecting to database")
 		if len(args) == 1 {
 			spinner.Start()
 			defer spinner.Stop()

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -241,12 +241,26 @@ func executeSQLFile(f *os.File, config shell.ShellConfig, path string, batchSize
 			continue
 		}
 
-		err := shell.RunShellLine(config, strings.Join(batch, "\n"))
+		err := executeBatch(batch, config, path, idx, batchSize)
 		if err != nil {
-			return fmt.Errorf("error executing SQL file %s batch %d of size %d: %w", path, idx, batchSize, err)
+			return err
 		}
+
 		idx += 1
 		batch = batch[:0]
+	}
+
+	return executeBatch(batch, config, path, idx, batchSize)
+}
+
+func executeBatch(batch []string, config shell.ShellConfig, path string, idx int, batchSize int) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	err := shell.RunShellLine(config, strings.Join(batch, "\n"))
+	if err != nil {
+		return fmt.Errorf("error executing SQL file %s batch %d of size %d: %w", path, idx, batchSize, err)
 	}
 
 	return nil

--- a/internal/cmd/db_update.go
+++ b/internal/cmd/db_update.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/spf13/cobra"
 )
@@ -54,7 +54,7 @@ var dbUpdateCmd = &cobra.Command{
 
 func update(client *turso.Client, name string) error {
 	msg := fmt.Sprintf("Updating database %s", internal.Emph(name))
-	s := prompt.Spinner(msg)
+	s := spinner.Start(msg)
 	defer s.Stop()
 
 	if err := client.Databases.Update(name); err != nil {

--- a/internal/cmd/from_file_flag.go
+++ b/internal/cmd/from_file_flag.go
@@ -5,5 +5,5 @@ import "github.com/spf13/cobra"
 var fromFileFlag string
 
 func addFromFileFlag(cmd *cobra.Command, usage string) {
-	cmd.Flags().StringVar(&fromFileFlag, "from-file", "", usage)
+	cmd.Flags().StringVarP(&fromFileFlag, "from-file", "f", "", usage)
 }

--- a/internal/cmd/from_file_flag.go
+++ b/internal/cmd/from_file_flag.go
@@ -4,6 +4,6 @@ import "github.com/spf13/cobra"
 
 var fromFileFlag string
 
-func addDbFromFileFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&fromFileFlag, "from-file", "", "create the database from a local SQLite3-compatible file")
+func addFromFileFlag(cmd *cobra.Command, usage string) {
+	cmd.Flags().StringVar(&fromFileFlag, "from-file", "", usage)
 }

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
+	"github.com/chiselstrike/iku-turso-cli/internal/prompt/spinner"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/olekukonko/tablewriter"
@@ -129,7 +129,7 @@ func printTable(header []string, data [][]string) {
 
 func destroyDatabase(client *turso.Client, name string) error {
 	start := time.Now()
-	s := prompt.Spinner(fmt.Sprintf("Destroying database %s... ", internal.Emph(name)))
+	s := spinner.Start(fmt.Sprintf("Destroying database %s... ", internal.Emph(name)))
 	defer s.Stop()
 
 	if err := client.Databases.Delete(name); err != nil {
@@ -152,7 +152,7 @@ func destroyDatabaseRegion(client *turso.Client, database, region string) error 
 		return fmt.Errorf("location '%s' is not a valid one", region)
 	}
 
-	s := prompt.Spinner(fmt.Sprintf("Destroying region %s of database %s... ", internal.Emph(region), internal.Emph(database)))
+	s := spinner.Start(fmt.Sprintf("Destroying region %s of database %s... ", internal.Emph(region), internal.Emph(database)))
 	defer s.Stop()
 
 	db, err := getDatabase(client, database)
@@ -192,7 +192,7 @@ func destroyDatabaseRegion(client *turso.Client, database, region string) error 
 }
 
 func destroyDatabaseInstance(client *turso.Client, database, instance string) error {
-	s := prompt.Spinner(fmt.Sprintf("Destroying instance %s of database %s... ", instance, internal.Emph(database)))
+	s := spinner.Start(fmt.Sprintf("Destroying instance %s of database %s... ", instance, internal.Emph(database)))
 	defer s.Stop()
 
 	err := deleteDatabaseInstance(client, database, instance)

--- a/internal/prompt/spinner/spinner.go
+++ b/internal/prompt/spinner/spinner.go
@@ -1,4 +1,4 @@
-package prompt
+package spinner
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-type spinner struct {
+type Spinner struct {
 	spinner   spn.Model
 	prefix    string
 	suffix    string
@@ -17,17 +17,17 @@ type spinner struct {
 	done      chan bool
 }
 
-func newSpinner(prefix, suffix string) *spinner {
+func newSpinner(prefix, suffix string) *Spinner {
 	s := spn.New()
 	s.Spinner = spn.Dot
-	return &spinner{spinner: s, prefix: prefix, suffix: suffix}
+	return &Spinner{spinner: s, prefix: prefix, suffix: suffix}
 }
 
-func (m *spinner) Init() tea.Cmd {
+func (m *Spinner) Init() tea.Cmd {
 	return m.spinner.Tick
 }
 
-func (m *spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *Spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.quitting {
 		return m, tea.Quit
 	}
@@ -48,25 +48,25 @@ func (m *spinner) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 }
 
-func (m *spinner) View() string {
+func (m *Spinner) View() string {
 	if m.quitting {
 		return ""
 	}
 	return fmt.Sprintf("%s%s %s", m.prefix, m.spinner.View(), m.suffix)
 }
 
-func (m *spinner) Stop() {
+func (m *Spinner) Stop() {
 	m.quitting = true
 	if m.done != nil {
 		<-m.done
 	}
 }
 
-func (m *spinner) Text(t string) {
+func (m *Spinner) Text(t string) {
 	m.suffix = t
 }
 
-func (m *spinner) Start() {
+func (m *Spinner) Start() {
 	ch := make(chan bool)
 	m.done = ch
 	m.quitting = false
@@ -80,13 +80,13 @@ func (m *spinner) Start() {
 	}()
 }
 
-func StoppedSpinner(text string) *spinner {
+func New(text string) *Spinner {
 	spinner := newSpinner("", text)
 	return spinner
 }
 
-func Spinner(text string) *spinner {
-	spinner := StoppedSpinner(text)
+func Start(text string) *Spinner {
+	spinner := New(text)
 	spinner.Start()
 	return spinner
 }


### PR DESCRIPTION
This will enable users to load dumps into Turso.
Since `turso db create --from-file` will fail for big enough files.

I created https://github.com/libsql/libsql-shell-go/issues/90 and https://github.com/libsql/libsql-shell-go/issues/91 to address the shortcomings found while implementing this PR.