### PR TITLE
Stop releasing for windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     binary: turso
     main: ./cmd/turso


### PR DESCRIPTION
One of our dependency modernc.org/sqlite does not build for windows.