### PR TITLE
Add --enable-extensions to turso db create

### DIFF
--- a/internal/cmd/canary_flag.go
+++ b/internal/cmd/canary_flag.go
@@ -2,8 +2,8 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-var canary bool
+var canaryFlag bool
 
 func addCanaryFlag(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&canary, "canary", false, "Use database canary build.")
+	cmd.Flags().BoolVar(&canaryFlag, "canary", false, "Use database canary build.")
 }

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -17,6 +17,7 @@ import (
 func init() {
 	dbCmd.AddCommand(createCmd)
 	addCanaryFlag(createCmd)
+	addEnableExtensionsFlag(createCmd)
 	addDbFromFileFlag(createCmd)
 	addLocationFlag(createCmd, "Location ID. If no ID is specified, closest location to you is used by default.")
 	addWaitFlag(createCmd, "Wait for the database to be ready to receive requests.")
@@ -61,6 +62,11 @@ var createCmd = &cobra.Command{
 			image = "canary"
 		}
 
+		extensions := ""
+		if enableExtensionsFlag {
+			extensions = "all"
+		}
+
 		dbFile, err := getDbFile(fromFileFlag)
 		if err != nil {
 			return err
@@ -77,7 +83,7 @@ var createCmd = &cobra.Command{
 		spinner := prompt.Spinner(description)
 		defer spinner.Stop()
 
-		if _, err := client.Databases.Create(name, region, image); err != nil {
+		if _, err := client.Databases.Create(name, region, image, extensions); err != nil {
 			return fmt.Errorf("could not create database %s: %w", name, err)
 		}
 

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -57,7 +57,7 @@ var createCmd = &cobra.Command{
 		}
 
 		image := "latest"
-		if canary {
+		if canaryFlag {
 			image = "canary"
 		}
 

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -57,7 +57,7 @@ var replicateCmd = &cobra.Command{
 		}
 
 		image := "latest"
-		if canary {
+		if canaryFlag {
 			image = "canary"
 		}
 

--- a/internal/cmd/enable_extensions_flag.go
+++ b/internal/cmd/enable_extensions_flag.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/chiselstrike/iku-turso-cli/internal"
+	"github.com/spf13/cobra"
+)
+
+var enableExtensionsFlag bool
+
+func addEnableExtensionsFlag(cmd *cobra.Command) {
+	usage := []string{
+		"Enables experimental support for SQLite extensions.",
+		"If you would like to see some extension included, run " + internal.Emph("turso account feedback") + ".",
+		internal.Warn("Warning") + ": extensions support is experimental and subject to change",
+	}
+	cmd.Flags().BoolVar(&enableExtensionsFlag, "enable-extensions", false, strings.Join(usage, "\n"))
+}

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -71,9 +71,9 @@ type CreateDatabaseResponse struct {
 	Password string
 }
 
-func (d *DatabasesClient) Create(name, region, image string) (*CreateDatabaseResponse, error) {
-	type Body struct{ Name, Region, Image string }
-	body, err := marshal(Body{name, region, image})
+func (d *DatabasesClient) Create(name, region, image, extensions string) (*CreateDatabaseResponse, error) {
+	type Body struct{ Name, Region, Image, Extensions string }
+	body, err := marshal(Body{name, region, image, extensions})
 	if err != nil {
 		return nil, fmt.Errorf("could not serialize request body: %w", err)
 	}


### PR DESCRIPTION
It allows users to enable extensions.
Usage:
```
➜  iku-turso-cli git:(athos/experimental) ✗ turso db create --help
Create a database.

Usage:
  turso db create [flags] [database_name]

Flags:
      --canary              Use database canary build.
      --enable-extensions   Enables experimental support for SQLite extensions.
                            The following extensions and extension sets are currently included:
                                - sqlean
                                - sqlite-vss
                            If you would like to see some extension included, run turso account feedback.
                            Warning: extensions support is experimental and subject to change
      --from-file string    create the database from a local SQLite3-compatible file
  -h, --help                help for create
      --location string     Location ID. If no ID is specified, closest location to you is used by default.
  -w, --wait                Wait for the database to be ready to receive requests.

Global Flags:
  -c, --config-path string                  Path to the directory with config file
      --no-multiple-token-sources-warning   Don't warn about multiple access token sources
```
      
```
turso db create --enable-extensions
```