### PR TITLE
remove dot

### DIFF
--- a/internal/cmd/dev.go
+++ b/internal/cmd/dev.go
@@ -58,7 +58,7 @@ var devCmd = &cobra.Command{
 		// Start the server process
 		err = sqld.Start()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s.\no install it, follow the instructions at %s.\nAlso make sure %s is on your PATH\n", internal.Warn("Could not start libsql-server"),
+			fmt.Fprintf(os.Stderr, "%s.\no install it, follow the instructions at %s\nAlso make sure %s is on your PATH\n", internal.Warn("Could not start libsql-server"),
 				internal.Emph("https://github.com/libsql/sqld/blob/main/docs/BUILD-RUN.md"),
 				internal.Emph("sqld"))
 			return err


### PR DESCRIPTION
A user just tried to copy and paste the URL in the browser, and because of the dot, terminals will include the dot in the URL if you click to copy.

Remove it