### PR TITLE
Get usage data from the API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/viper v1.15.0
-	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/sync v0.1.0
 )
@@ -73,6 +72,7 @@ require (
 	github.com/muesli/termenv v0.13.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	nhooyr.io/websocket v1.8.7 // indirect

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -1,15 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"time"
-
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
-	"github.com/chiselstrike/iku-turso-cli/internal/settings"
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
@@ -22,17 +17,7 @@ var accountShowCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		settings, err := settings.ReadSettings()
-		if err != nil {
-			return err
-		}
-
 		client, err := createTursoClientFromAccessToken(true)
-		if err != nil {
-			return err
-		}
-
-		databases, err := client.Databases.List()
 		if err != nil {
 			return err
 		}
@@ -42,58 +27,9 @@ var accountShowCmd = &cobra.Command{
 			return err
 		}
 
-		numDatabases := len(databases)
-		numLocations := 0
-		inspectRet := InspectInfo{}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		// FIXME: this should be done at the server so we can enforce it
-		var dbTokens []string
-		var dbInstances [][]turso.Instance
-		var instanceCount int
-		for _, database := range databases {
-			numLocations += len(database.Regions)
-			instances, err := client.Instances.List(database.Name)
-			if err != nil {
-				return err
-			}
-
-			token, err := client.Databases.Token(database.Name, "1d", true)
-			if err != nil {
-				return err
-			}
-
-			dbTokens = append(dbTokens, token)
-			instanceCount += len(instances)
-			dbInstances = append(dbInstances, instances)
-		}
-		inspectResCh := make(chan *InspectInstanceInfo, instanceCount)
-		g, ctx := errgroup.WithContext(ctx)
-		for idx, database := range databases {
-			idx := idx
-			database := database
-			for _, instance := range dbInstances[idx] {
-				instance := instance
-				g.Go(func() error {
-					url := getInstanceHttpUrl(settings, &database, &instance)
-					ret, err := inspectInstance(ctx, url, dbTokens[idx])
-					if err != nil {
-						return err
-					}
-					ret.Location = instance.Region
-					ret.Name = instance.Name
-					ret.Type = instance.Type
-					inspectResCh <- ret
-					return nil
-				})
-			}
-		}
-		if err := g.Wait(); err != nil {
+		usage, err := client.Organizations.Usage()
+		if err != nil {
 			return err
-		}
-		for i := 0; i < instanceCount; i++ {
-			ret := <-inspectResCh
-			inspectRet.Accumulate(ret)
 		}
 
 		fmt.Printf("You are currently on %s plan.\n", internal.Emph(userInfo.Plan))
@@ -111,10 +47,10 @@ var accountShowCmd = &cobra.Command{
 
 		planInfo := getPlanInfo(PlanType(userInfo.Plan))
 
-		tbl.AddRow("storage", inspectRet.PrintTotalStorage(), planInfo.maxStorage)
-		tbl.AddRow("rows read", inspectRet.TotalRowsReadCount(), fmt.Sprintf("%d", int(1e9)))
-		tbl.AddRow("databases", numDatabases, planInfo.maxDatabases)
-		tbl.AddRow("locations", numLocations, planInfo.maxLocation)
+		tbl.AddRow("storage", humanize.IBytes(usage.Total.StorageBytesUsed), planInfo.maxStorage)
+		tbl.AddRow("rows read", usage.Total.RowsRead, fmt.Sprintf("%d", int(1e9)))
+		tbl.AddRow("databases", usage.Total.Databases, planInfo.maxDatabases)
+		tbl.AddRow("locations", usage.Total.Locations, planInfo.maxLocation)
 		tbl.Print()
 
 		return nil

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -1,24 +1,12 @@
 package cmd
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"github.com/rodaine/table"
-	"io"
-	"net/http"
-	"sort"
-	"strings"
-	"time"
 
-	"github.com/chiselstrike/iku-turso-cli/internal/settings"
-	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/rodaine/table"
+
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
-	"github.com/xwb1989/sqlparser"
-	"golang.org/x/sync/errgroup"
 )
 
 func init() {
@@ -93,37 +81,6 @@ func (curr *InspectInfo) TotalRowsReadCount() uint64 {
 	return total
 }
 
-func (curr *InspectInfo) show(detailed bool) {
-	if !detailed {
-		tables := humanize.IBytes(curr.totalTablesSize())
-		indexes := humanize.IBytes(curr.totalIndexesSize())
-		rowsRead := fmt.Sprintf("%d", curr.TotalRowsReadCount())
-		fmt.Printf("Total space used for tables: %s\n", tables)
-		fmt.Printf("Total space used for indexes: %s\n", indexes)
-		fmt.Printf("Number of rows read: %s\n", rowsRead)
-	} else {
-		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "TABLE STORAGE", "INDEX STORAGE")
-		for _, instanceInfo := range curr.instanceInfos {
-			tbl.AddRow(instanceInfo.Location, instanceInfo.Type, instanceInfo.Name, instanceInfo.RowsReadCount, humanize.IBytes(instanceInfo.totalTablesSize()), humanize.IBytes(instanceInfo.totalIndexesSize()))
-		}
-		tbl.AddRow("", "", "TOTAL", curr.TotalRowsReadCount(), humanize.IBytes(curr.totalTablesSize()), humanize.IBytes(curr.totalIndexesSize()))
-		tbl.Print()
-
-		sort.Slice(curr.instanceInfos, func(i, j int) bool {
-			return curr.instanceInfos[i].Location < curr.instanceInfos[j].Location
-		})
-		for _, instanceInfo := range curr.instanceInfos {
-			fmt.Println()
-			fmt.Printf("For location: %s\n", instanceInfo.Location)
-			tbl := table.New("TYPE", "NAME", "SIZE")
-			for _, storageInfo := range instanceInfo.StorageInfos {
-				tbl.AddRow(storageInfo.Type, storageInfo.Name, humanize.IBytes(storageInfo.SizeTables+storageInfo.SizeIndexes))
-			}
-			tbl.Print()
-		}
-	}
-}
-
 var dbInspectCmd = &cobra.Command{
 	Use:               "inspect {database_name}",
 	Short:             "Inspect database.",
@@ -141,293 +98,39 @@ var dbInspectCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		db, err := getDatabase(client, name)
 		if err != nil {
 			return err
 		}
 
-		config, err := settings.ReadSettings()
+		instances, usages, err := instancesAndUsage(client, db.Name)
 		if err != nil {
 			return err
 		}
 
-		instances, err := client.Instances.List(db.Name)
-		if err != nil {
-			return err
+		fmt.Printf("Total space used: %s\n", humanize.IBytes(usages.Total.StorageBytesUsed))
+		fmt.Printf("Number of rows read: %d\n", usages.Total.RowsRead)
+		fmt.Printf("Number of rows written: %d\n", usages.Total.RowsWritten)
+
+		if !verboseFlag {
+			return nil
 		}
 
-		token, err := client.Databases.Token(db.Name, "1d", true)
-		if err != nil {
-			return err
+		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "ROWS WRITTEN", "TOTAL STORAGE")
+		for _, instance := range instances {
+			usg, ok := usages.Instances[instance.Uuid]
+			if !ok {
+				tbl.AddRow(instance.Region, instance.Type, instance.Name, "-", "-", "-")
+				continue
+			}
+			tbl.AddRow(instance.Region, instance.Type, instance.Name, usg.RowsRead, usg.RowsWritten, humanize.IBytes(usg.StorageBytesUsed))
 		}
 
-		inspectInfo, err := inspectInstances(instances, config, db, token)
-		if err != nil {
-			return err
-		}
+		fmt.Println()
+		tbl.Print()
+		fmt.Println()
 
-		inspectInfo.show(verboseFlag)
 		return nil
 	},
-}
-
-func calculateInstancesUsedSize(instances []turso.Instance, config *settings.Settings, db turso.Database, token string) string {
-	inspectInfo, err := inspectInstances(instances, config, db, token)
-	if err != nil {
-		return fmt.Sprintf("fetching size failed: %s", err)
-	}
-	return inspectInfo.PrintTotalStorage()
-}
-
-func inspectInstances(instances []turso.Instance, config *settings.Settings, db turso.Database, token string) (*InspectInfo, error) {
-	inspectInfo := &InspectInfo{}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	g, ctx := errgroup.WithContext(ctx)
-	results := make(chan *InspectInstanceInfo, len(instances))
-	for _, instance := range instances {
-		loopInstance := instance
-		g.Go(func() error {
-			url := getInstanceHttpUrl(config, &db, &loopInstance)
-			ret, err := inspectInstance(ctx, url, token)
-			if err != nil {
-				return err
-			}
-			ret.Location = loopInstance.Region
-			ret.Name = loopInstance.Name
-			ret.Type = loopInstance.Type
-			results <- ret
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return &InspectInfo{}, fmt.Errorf("timeout while inspecting database. It's possible that this database is too old and does not support inspecting or one of the instances is not reachable")
-		}
-		return &InspectInfo{}, err
-	}
-	for range instances {
-		ret := <-results
-		inspectInfo.Accumulate(ret)
-	}
-
-	return inspectInfo, nil
-}
-
-type GetInstancesInfoReturnType struct {
-	size     string
-	versions []chan string
-	urls     []string
-}
-
-func getInstancesInfo(client *turso.Client, instances []turso.Instance, config *settings.Settings, db turso.Database, token string) GetInstancesInfoReturnType {
-	versions := [](chan string){}
-	urls := []string{}
-
-	for idx, instance := range instances {
-		urls = append(urls, getInstanceUrl(config, &db, &instance))
-		versions = append(versions, make(chan string, 1))
-		go func(idx int, client *turso.Client, config *settings.Settings, db *turso.Database, instance *turso.Instance) {
-			versions[idx] <- fetchInstanceVersion(client, config, db, instance)
-		}(idx, client, config, &db, &instance)
-	}
-
-	instancesInfo := GetInstancesInfoReturnType{
-		size:     calculateInstancesUsedSize(instances, config, db, token),
-		versions: versions,
-		urls:     urls,
-	}
-	return instancesInfo
-}
-
-func inspectInstance(ctx context.Context, url, token string) (*InspectInstanceInfo, error) {
-	inspectComputeResult := make(chan uint64, 1)
-	go func() {
-		rowsRead, err := inspectCompute(ctx, url, token)
-		if err != nil {
-			rowsRead = 0
-		}
-		inspectComputeResult <- rowsRead
-	}()
-	storageInfos, err := inspectStorage(ctx, url, token)
-	if err != nil {
-		return nil, err
-	}
-	rowsRead := <-inspectComputeResult
-	return &InspectInstanceInfo{
-		StorageInfos:  storageInfos,
-		RowsReadCount: rowsRead,
-	}, nil
-}
-
-func inspectCompute(ctx context.Context, url, token string) (uint64, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url+"/v1/stats", nil)
-	if err != nil {
-		return 0, err
-	}
-	if token != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
-	var results struct {
-		RowsReadCount uint64 `json:"rows_read_count"`
-	}
-	if err := json.Unmarshal(body, &results); err != nil {
-		return 0, err
-	}
-	return results.RowsReadCount, nil
-}
-
-func getTypeMap(ctx context.Context, url, token string) (map[string]string, error) {
-	typeStmt := `select name, type from sqlite_schema where
-	name != 'sqlite_schema'
-        and name != '_litestream_seq'
-        and name != '_litestream_lock'
-        and name != 'libsql_wasm_func_table'`
-	respType, err := doQueryContext(ctx, url, token, typeStmt)
-	if err != nil {
-		return nil, err
-	}
-	defer respType.Body.Close()
-	bodyType, err := io.ReadAll(respType.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if respType.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error: %s", string(bodyType))
-	}
-
-	var typeResults []QueryResult
-	if err := json.Unmarshal(bodyType, &typeResults); err != nil {
-		return nil, err
-	}
-
-	typeMap := make(map[string]string)
-	for _, result := range typeResults {
-		if result.Results != nil {
-			for _, row := range result.Results.Rows {
-				typeMap[row[0].(string)] = row[1].(string)
-			}
-		}
-	}
-
-	return typeMap, nil
-}
-
-func inspectStorage(ctx context.Context, url, token string) ([]StorageInfo, error) {
-	typeMapResult := make(chan map[string]string)
-	typeMapError := make(chan error)
-	go func() {
-		typeMap, err := getTypeMap(ctx, url, token)
-		if err != nil {
-			typeMapError <- err
-		} else {
-			typeMapResult <- typeMap
-		}
-	}()
-
-	stmt := `select name, SUM(pgsize) as size from dbstat
-	where name != 'sqlite_schema'
-        and name != '_litestream_seq'
-        and name != '_litestream_lock'
-        and name != 'libsql_wasm_func_table'
-	group by name
-	order by size desc, name asc`
-	resp, err := doQueryContext(ctx, url, token, stmt)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("error: %s", string(body))
-	}
-
-	var results []QueryResult
-	if err := json.Unmarshal(body, &results); err != nil {
-		return nil, err
-	}
-
-	var typeMap map[string]string
-	select {
-	case err := <-typeMapError:
-		return nil, err
-	case typeMap = <-typeMapResult:
-	}
-
-	var errs []string
-	var res []StorageInfo
-	for _, result := range results {
-		if result.Error != nil {
-			errs = append(errs, result.Error.Message)
-		}
-		if result.Results != nil {
-			for _, row := range result.Results.Rows {
-				type_ := "?"
-				name := row[0].(string)
-				if t, ok := typeMap[name]; ok {
-					type_ = t
-				}
-				size := uint64(row[1].(float64))
-				storageInfo := StorageInfo{}
-				storageInfo.Type = type_
-				storageInfo.Name = name
-				if type_ == "index" {
-					storageInfo.SizeIndexes = size
-				} else {
-					storageInfo.SizeTables = size
-				}
-				res = append(res, storageInfo)
-			}
-		}
-	}
-	if len(errs) > 0 {
-		return nil, &SqlError{(strings.Join(errs, "; "))}
-	}
-	return res, nil
-}
-
-type SqlError struct {
-	Message string
-}
-
-func (e *SqlError) Error() string {
-	return e.Message
-}
-
-func doQueryContext(ctx context.Context, url, token, stmt string) (*http.Response, error) {
-	stmts, err := sqlparser.SplitStatementToPieces(stmt)
-	if err != nil {
-		return nil, err
-	}
-	rawReq := QueryRequest{
-		Statements: stmts,
-	}
-	body, err := json.Marshal(rawReq)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	if token != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
-	}
-	return http.DefaultClient.Do(req)
 }

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -83,10 +83,6 @@ func getDatabaseHttpUrl(settings *settings.Settings, db *turso.Database) string 
 	return getUrl(settings, db, nil, "https")
 }
 
-func getInstanceHttpUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance) string {
-	return getUrl(settings, db, inst, "https")
-}
-
 func getUrl(settings *settings.Settings, db *turso.Database, inst *turso.Instance, scheme string) string {
 	host := db.Hostname
 	if inst != nil {
@@ -303,4 +299,18 @@ func fetchLatestVersion() (string, error) {
 		return "", fmt.Errorf("got empty version for latest release")
 	}
 	return versionResp.Version, nil
+}
+
+func instancesAndUsage(client *turso.Client, database string) (instances []turso.Instance, usage turso.DbUsage, err error) {
+	g := errgroup.Group{}
+	g.Go(func() (err error) {
+		instances, err = client.Instances.List(database)
+		return
+	})
+	g.Go(func() (err error) {
+		usage, err = client.Databases.Usage(database)
+		return
+	})
+	err = g.Wait()
+	return
 }

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -229,6 +229,30 @@ func (d *DatabasesClient) Update(database string) error {
 	return nil
 }
 
+type Usage struct {
+	RowsRead         uint64 `json:"rows_read,omitempty"`
+	RowsWritten      uint64 `json:"rows_written,omitempty"`
+	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
+}
+
+type DbUsage struct {
+	Instances map[string]Usage `json:"instances"`
+	Total     Usage            `json:"total"`
+}
+
+func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
+	url := d.URL(fmt.Sprintf("/%s/usage", database))
+
+	r, err := d.client.Get(url, nil)
+	if err != nil {
+		return DbUsage{}, fmt.Errorf("failed to get database usage: %w", err)
+	}
+	defer r.Body.Close()
+
+	body, err := unmarshal[DbUsage](r)
+	return body, err
+}
+
 func (d *DatabasesClient) URL(suffix string) string {
 	prefix := "/v1"
 	if d.client.org != "" {

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -87,6 +87,35 @@ func (c *OrganizationsClient) Delete(slug string) error {
 	}
 }
 
+type OrgTotal struct {
+	RowsRead         uint64 `json:"rows_read,omitempty"`
+	RowsWritten      uint64 `json:"rows_written,omitempty"`
+	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
+	Databases        uint64 `json:"databases,omitempty"`
+	Locations        uint64 `json:"locations,omitempty"`
+}
+
+type OrgUsage struct {
+	Databases map[string]DbUsage `json:"databases"`
+	Total     OrgTotal           `json:"total"`
+}
+
+func (c *OrganizationsClient) Usage() (OrgUsage, error) {
+	prefix := "/v1"
+	if c.client.org != "" {
+		prefix = "/v1/organizations/" + c.client.org
+	}
+
+	r, err := c.client.Get(prefix+"/usage", nil)
+	if err != nil {
+		return OrgUsage{}, fmt.Errorf("failed to get database usage: %w", err)
+	}
+	defer r.Body.Close()
+
+	body, err := unmarshal[OrgUsage](r)
+	return body, err
+}
+
 type Member struct {
 	Name string `json:"username,omitempty"`
 	Role string `json:"role,omitempty"`


### PR DESCRIPTION
This makes some major changes in how we report usage.
We stop querying it directly from the databases and get it from Turso API.

It has the benefit of providing much faster results and simplifying the client logic.
It brings some regressions as well:
- We don't have data in the backend regarding index storage size.
- We account for all tables when calculating the total DB size, we do not discount internal ones.

Both will be addressed in the next iterations.

---

Examples:

```
➜  iku-turso-cli git:(athos/usage) turso db list
NAME                  LOCATIONS                        URL                                            
choice-fantomette     gru (primary), iad, scl, yyz     libsql://choice-fantomette-athoscouto.turso.io     
```

```
➜  iku-turso-cli git:(athos/usage) turso db inspect choice-fantomette --verbose
Total space used: 96 KiB
Number of rows read: 119
Number of rows written: 5

LOCATION  TYPE     INSTANCE NAME        ROWS READ  ROWS WRITTEN  TOTAL STORAGE  
gru       primary  superb-colleen       89         5             24 KiB         
iad       replica  accurate-hooded      10         0             24 KiB         
scl       replica  charmed-glitter      10         0             24 KiB         
yyz       replica  polite-sinister-six  10         0             24 KiB         
```

```
➜  iku-turso-cli git:(athos/usage) turso db show choice-fantomette             
Name:           choice-fantomette
URL:            libsql://choice-fantomette-athoscouto.turso.io
ID:             5dc880a4-047f-11ee-bfbd-f6eaba957d3d
Locations:      gru, iad, scl, yyz
Size:           96 KiB

Database Instances:
NAME                    TYPE        LOCATION 
superb-colleen          primary     gru          
accurate-hooded         replica     iad          
charmed-glitter         replica     scl          
polite-sinister-six     replica     yyz          
```
```      
➜  iku-turso-cli git:(athos/usage) turso account show
You are currently on starter plan.

RESOURCE   USED    MAX         
storage    96 KiB  8.0 GiB     
rows read  290     1000000000  
databases  1       3           
locations  4       3           
```