### PR TITLE
Improve error message for personal organization

### DIFF
--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -202,7 +202,7 @@ func (c *OrganizationsClient) RemoveMember(username string) error {
 
 func (c *OrganizationsClient) MembersURL(suffix string) (string, error) {
 	if c.client.org == "" {
-		return "", fmt.Errorf("cannot manage members of personal organization")
+		return "", fmt.Errorf("the currently active organization %s does not allow members. You can use %s to change active organization", internal.Emph("personal"), internal.Emph("turso org switch"))
 	}
 	return "/v1/organizations/" + c.client.org + "/members" + suffix, nil
 }


### PR DESCRIPTION
The personal organization is special and doesn't allow you to add members. Let's improve the error message to make that more explicit.

Before:

  Error: cannot manage members of personal organization

After:

  Error: the personal organization currently selected doesn't allow members. You can use turso auth login to switch organizations.