### PR TITLE
add rows written row in account show command

### DIFF
--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -49,6 +49,7 @@ var accountShowCmd = &cobra.Command{
 
 		tbl.AddRow("storage", humanize.IBytes(usage.Total.StorageBytesUsed), planInfo.maxStorage)
 		tbl.AddRow("rows read", usage.Total.RowsRead, fmt.Sprintf("%d", int(1e9)))
+		tbl.AddRow("rows written", usage.Total.RowsWritten, fmt.Sprintf("%d", int(1e9)))
 		tbl.AddRow("databases", usage.Total.Databases, planInfo.maxDatabases)
 		tbl.AddRow("locations", usage.Total.Locations, planInfo.maxLocation)
 		tbl.Print()


### PR DESCRIPTION
Addressing #483 

- Added rows written metric in the account show command

![image](https://github.com/chiselstrike/turso-cli/assets/40317114/f0e8bb98-da59-4ffc-87f8-96cb6f880f1f)

Let me know about further changes.
Thank you