### PR TITLE
turso plan show improvements

### DIFF
--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -94,5 +94,5 @@ func addResourceRowCount(tbl table.Table, resource string, used, limit uint64) {
 }
 
 func percentage(used, limit float64) string {
-	return fmt.Sprintf("%.0f %%", used/limit*100)
+	return fmt.Sprintf("%.0f%%", used/limit*100)
 }

--- a/internal/cmd/account_show.go
+++ b/internal/cmd/account_show.go
@@ -39,7 +39,7 @@ var accountShowCmd = &cobra.Command{
 		columns = append(columns, "RESOURCE")
 		columns = append(columns, "USED")
 		columns = append(columns, "LIMIT")
-		columns = append(columns, "PERCENTAGE")
+		columns = append(columns, "USED %")
 
 		tbl := table.New(columns...)
 

--- a/internal/cmd/preview.go
+++ b/internal/cmd/preview.go
@@ -86,8 +86,8 @@ var planShowCmd = &cobra.Command{
 		tbl.WithFirstColumnFormatter(columnFmt)
 
 		addResourceRowBytes(tbl, "storage", usage.Total.StorageBytesUsed, current.Quotas.Storage)
-		addResourceRowCount(tbl, "rows read", usage.Total.RowsRead, current.Quotas.RowsRead)
-		addResourceRowCount(tbl, "rows written", usage.Total.RowsWritten, current.Quotas.RowsWritten)
+		addResourceRowMillions(tbl, "rows read", usage.Total.RowsRead, current.Quotas.RowsRead)
+		addResourceRowMillions(tbl, "rows written", usage.Total.RowsWritten, current.Quotas.RowsWritten)
 		addResourceRowCount(tbl, "databases", usage.Total.Databases, current.Quotas.Databases)
 		addResourceRowCount(tbl, "locations", usage.Total.Locations, current.Quotas.Locations)
 		tbl.Print()

--- a/internal/cmd/preview.go
+++ b/internal/cmd/preview.go
@@ -66,6 +66,9 @@ var planShowCmd = &cobra.Command{
 			return err
 		}
 
+		if client.Org != "" {
+			fmt.Printf("Organization: %s\n", internal.Emph(client.Org))
+		}
 		fmt.Printf("Active plan: %s\n", internal.Emph(plan.Active))
 		if plan.Scheduled != "" {
 			fmt.Printf("Starting next month: %s\n", internal.Emph(plan.Scheduled))

--- a/internal/turso/billing.go
+++ b/internal/turso/billing.go
@@ -10,8 +10,8 @@ type Portal struct {
 
 func (c *BillingClient) Portal() (Portal, error) {
 	prefix := "/v1"
-	if c.client.org != "" {
-		prefix = "/v1/organizations/" + c.client.org
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
 	}
 
 	r, err := c.client.Post(prefix+"/billing/portal", nil)
@@ -30,8 +30,8 @@ func (c *BillingClient) Portal() (Portal, error) {
 
 func (c *BillingClient) HasPaymentMethod() (bool, error) {
 	prefix := "/v1"
-	if c.client.org != "" {
-		prefix = "/v1/organizations/" + c.client.org
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
 	}
 	r, err := c.client.Get(prefix+"/billing/payment-methods", nil)
 	if err != nil {

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -25,7 +25,7 @@ func (d *DatabasesClient) List() ([]Database, error) {
 	}
 	defer r.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return nil, notMemberErr(org)
 	}
@@ -49,7 +49,7 @@ func (d *DatabasesClient) Delete(database string) error {
 	}
 	defer r.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return notMemberErr(org)
 	}
@@ -83,7 +83,7 @@ func (d *DatabasesClient) Create(name, region, image, extensions string) (*Creat
 	}
 	defer res.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(res.StatusCode, org) {
 		return nil, notMemberErr(org)
 	}
@@ -112,7 +112,7 @@ func (d *DatabasesClient) Seed(name string, dbFile *os.File) error {
 	}
 	defer res.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(res.StatusCode, org) {
 		return notMemberErr(org)
 	}
@@ -139,7 +139,7 @@ func (d *DatabasesClient) Token(database string, expiration string, readOnly boo
 	}
 	defer r.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return "", notMemberErr(org)
 	}
@@ -165,7 +165,7 @@ func (d *DatabasesClient) Rotate(database string) error {
 	}
 	defer r.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return notMemberErr(org)
 	}
@@ -186,7 +186,7 @@ func (d *DatabasesClient) Update(database string) error {
 	}
 	defer r.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return notMemberErr(org)
 	}
@@ -225,8 +225,8 @@ func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
 
 func (d *DatabasesClient) URL(suffix string) string {
 	prefix := "/v1"
-	if d.client.org != "" {
-		prefix = "/v1/organizations/" + d.client.org
+	if d.client.Org != "" {
+		prefix = "/v1/organizations/" + d.client.Org
 	}
 	return prefix + "/databases" + suffix
 }

--- a/internal/turso/instances.go
+++ b/internal/turso/instances.go
@@ -23,7 +23,7 @@ func (i *InstancesClient) List(db string) ([]Instance, error) {
 	}
 	defer r.Body.Close()
 
-	org := i.client.org
+	org := i.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return nil, notMemberErr(org)
 	}
@@ -49,7 +49,7 @@ func (i *InstancesClient) Delete(db, instance string) error {
 	}
 	defer r.Body.Close()
 
-	org := i.client.org
+	org := i.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return notMemberErr(org)
 	}
@@ -88,7 +88,7 @@ func (d *InstancesClient) Create(dbName, instanceName, region, image string) (*I
 	}
 	defer res.Body.Close()
 
-	org := d.client.org
+	org := d.client.Org
 	if isNotMemberErr(res.StatusCode, org) {
 		return nil, notMemberErr(org)
 	}
@@ -113,7 +113,7 @@ func (i *InstancesClient) Wait(db, instance string) error {
 	}
 	defer r.Body.Close()
 
-	org := i.client.org
+	org := i.client.Org
 	if isNotMemberErr(r.StatusCode, org) {
 		return notMemberErr(org)
 	}
@@ -137,8 +137,8 @@ func (i *InstancesClient) Wait(db, instance string) error {
 
 func (d *InstancesClient) URL(database, suffix string) string {
 	prefix := "/v1"
-	if d.client.org != "" {
-		prefix = "/v1/organizations/" + d.client.org
+	if d.client.Org != "" {
+		prefix = "/v1/organizations/" + d.client.Org
 	}
 	return fmt.Sprintf("%s/databases/%s/instances%s", prefix, database, suffix)
 }

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -106,8 +106,8 @@ type OrgUsage struct {
 
 func (c *OrganizationsClient) Usage() (OrgUsage, error) {
 	prefix := "/v1"
-	if c.client.org != "" {
-		prefix = "/v1/organizations/" + c.client.org
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
 	}
 
 	r, err := c.client.Get(prefix+"/usage", nil)
@@ -205,10 +205,10 @@ func (c *OrganizationsClient) RemoveMember(username string) error {
 }
 
 func (c *OrganizationsClient) MembersURL(suffix string) (string, error) {
-	if c.client.org == "" {
+	if c.client.Org == "" {
 		return "", fmt.Errorf("the currently active organization %s does not allow members. You can use %s to change active organization", internal.Emph("personal"), internal.Emph("turso org switch"))
 	}
-	return "/v1/organizations/" + c.client.org + "/members" + suffix, nil
+	return "/v1/organizations/" + c.client.Org + "/members" + suffix, nil
 }
 
 func unsetOrganization() error {

--- a/internal/turso/plans.go
+++ b/internal/turso/plans.go
@@ -42,8 +42,8 @@ type OrgPlan struct {
 
 func (c *PlansClient) Get() (OrgPlan, error) {
 	prefix := "/v1"
-	if c.client.org != "" {
-		prefix = "/v1/organizations/" + c.client.org
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
 	}
 
 	r, err := c.client.Get(prefix+"/plan", nil)
@@ -64,8 +64,8 @@ var ErrPaymentRequired = errors.New("payment required")
 
 func (c *PlansClient) Set(plan string) (OrgPlan, error) {
 	prefix := "/v1"
-	if c.client.org != "" {
-		prefix = "/v1/organizations/" + c.client.org
+	if c.client.Org != "" {
+		prefix = "/v1/organizations/" + c.client.Org
 	}
 
 	body, err := marshal(struct {

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -15,7 +15,7 @@ type Client struct {
 	baseUrl    *url.URL
 	token      string
 	cliVersion string
-	org        string
+	Org        string
 
 	// Single instance to be reused by all clients
 	base *client
@@ -38,7 +38,7 @@ type client struct {
 }
 
 func New(base *url.URL, token string, cliVersion string, org string) *Client {
-	c := &Client{baseUrl: base, token: token, cliVersion: cliVersion, org: org}
+	c := &Client{baseUrl: base, token: token, cliVersion: cliVersion, Org: org}
 
 	c.base = &client{c}
 	c.Instances = (*InstancesClient)(c.base)


### PR DESCRIPTION
closes https://github.com/chiselstrike/turso-cli/issues/491

---

Example output:
```
Organization: test
Active plan: scaler

RESOURCE      USED  LIMIT    PERCENTAGE  
storage       0 B   20 GiB   0%          
rows read     0M    100000M  0%          
rows written  0M    100M     0%          
databases     0     6        0%          
locations     0     6        0%          
```

Example output on personal org:
```
Active plan: scaler

RESOURCE      USED   LIMIT    PERCENTAGE  
storage       0 B    20 GiB   0%          
rows read     <0.1M  100000M  0%          
rows written  <0.1M  100M     0%          
databases     2      6        33%         
locations     2      6        33%         
```

Example of formating of rows counter:
```
/*
fmt.Println(toM(0))
fmt.Println(toM(1))
fmt.Println(toM(300000))
fmt.Println(toM(1000000))
fmt.Println(toM(2350000))
fmt.Println(toM(1000000000))
*/

0M
>0.1M
0.3M
1M
2.4M
1000M
```
---

I'm not happy with not having spaces between numbers and `M` suffix but having them for bytes.
I'd rather remove spaces from everything, looks better, IMO.
Let me know if you have opinions on this.