### PR TITLE
fix shell issues when connecting to specific URLs

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -17,7 +17,6 @@ var showHttpUrlFlag bool
 var showInstanceUrlsFlag bool
 var showInstanceUrlFlag string
 var yesFlag bool
-var instanceFlag string
 
 func getInstanceNames(client *turso.Client, dbName string) []string {
 	instances, err := client.Instances.List(dbName)

--- a/internal/cmd/db_destroy.go
+++ b/internal/cmd/db_destroy.go
@@ -11,7 +11,7 @@ func init() {
 	dbCmd.AddCommand(destroyCmd)
 	destroyCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Confirms the destruction of all locations of the database.")
 	addLocationFlag(destroyCmd, "Pick a database location to destroy.")
-	destroyCmd.Flags().StringVar(&instanceFlag, "instance", "", "Pick a specific database instance to destroy.")
+	addInstanceFlag(destroyCmd, "Pick a specific database instance to destroy.")
 	destroyCmd.RegisterFlagCompletionFunc("instance", completeInstanceName)
 }
 

--- a/internal/cmd/instance_flag.go
+++ b/internal/cmd/instance_flag.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var instanceFlag string
+
+func addInstanceFlag(cmd *cobra.Command, desc string) {
+	cmd.Flags().StringVar(&instanceFlag, "instance", "", desc)
+}

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -83,6 +83,10 @@ func getDatabaseHttpUrl(db *turso.Database) string {
 	return getUrl(db, nil, "https")
 }
 
+func getInstanceHttpUrl(db *turso.Database, inst *turso.Instance) string {
+	return getUrl(db, inst, "https")
+}
+
 func getUrl(db *turso.Database, inst *turso.Instance, scheme string) string {
 	host := db.Hostname
 	if inst != nil {


### PR DESCRIPTION
There are two issues when connecting to specific URLs that are fixed by this PR:

1. When connecting to non-turso URLs (like localhost running sqld), we will try to get turso tokens first, which will obviously fail. The code depends on db objects very early, so the best way is to test if an URL is turso.io (or not an URL), and only try to get to tokens in that case.

2. When connecting to specific DB instances, the current code is mistakenly overriding the dbURL with the URL we get from the DB name. That's just plain wrong, and is fixed here.