### PR TITLE
Cache `db list` response (fixes #502)

### DIFF
--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -66,14 +66,6 @@ func convertInternalDbToCachedDb(databases []turso.Database) []settings.Database
 	return dbs
 }
 
-func fetchDatabaseNames(client *turso.Client) []string {
-	databases, err := client.Databases.List()
-	if err != nil {
-		return []string{}
-	}
-	return extractDatabaseNames(databases)
-}
-
 func getDatabase(client *turso.Client, name string) (turso.Database, error) {
 	databases, err := client.Databases.List()
 	if err != nil {

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -38,6 +38,34 @@ func extractDatabaseNames(databases []turso.Database) []string {
 	return names
 }
 
+func convertCachedDbToInternalDb(databases []settings.Database) []turso.Database {
+	dbs := make([]turso.Database, 0)
+	for _, database := range databases {
+		dbs = append(dbs, turso.Database{
+			ID:            database.ID,
+			Name:          database.Name,
+			Regions:       database.Regions,
+			PrimaryRegion: database.PrimaryRegion,
+			Hostname:      database.Hostname,
+		})
+	}
+	return dbs
+}
+
+func convertInternalDbToCachedDb(databases []turso.Database) []settings.Database {
+	dbs := make([]settings.Database, 0)
+	for _, database := range databases {
+		dbs = append(dbs, settings.Database{
+			ID:            database.ID,
+			Name:          database.Name,
+			Regions:       database.Regions,
+			PrimaryRegion: database.PrimaryRegion,
+			Hostname:      database.Hostname,
+		})
+	}
+	return dbs
+}
+
 func fetchDatabaseNames(client *turso.Client) []string {
 	databases, err := client.Databases.List()
 	if err != nil {
@@ -61,18 +89,28 @@ func getDatabase(client *turso.Client, name string) (turso.Database, error) {
 	return turso.Database{}, fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(name), internal.Emph("turso db list"))
 }
 
-func getDatabaseNames(client *turso.Client) []string {
+func getDatabasesCacheOrAPI(client *turso.Client) ([]turso.Database, error) {
 	settings, err := settings.ReadSettings()
 	if err != nil {
-		return fetchDatabaseNames(client)
+		return nil, err
 	}
-	cached_names := settings.GetDbNamesCache()
-	if cached_names != nil {
-		return cached_names
+	if cachedNames := settings.GetDatabasesCache(); cachedNames != nil {
+		return convertCachedDbToInternalDb(cachedNames), nil
 	}
-	names := fetchDatabaseNames(client)
-	settings.SetDbNamesCache(names)
-	return names
+	databases, err := client.Databases.List()
+	if err != nil {
+		return nil, err
+	}
+	settings.SetDatabasesCache(convertInternalDbToCachedDb(databases))
+	return databases, nil
+}
+
+func getDatabaseNames(client *turso.Client) []string {
+	databases, err := getDatabasesCacheOrAPI(client)
+	if err != nil {
+		return []string{}
+	}
+	return extractDatabaseNames(databases)
 }
 
 func completeInstanceName(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -230,7 +230,7 @@ var createCmd = &cobra.Command{
 		fmt.Printf("To see information about the database, including a connection URL, run:\n\n")
 		fmt.Printf("   turso db show %s\n\n", name)
 
-		config.InvalidateDbNamesCache()
+		config.InvalidateDatabasesCache()
 
 		return nil
 	},

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"sort"
 
-	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/spf13/cobra"
 )
 
@@ -18,20 +17,14 @@ var listCmd = &cobra.Command{
 	ValidArgsFunction: noFilesArg,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		settings, err := settings.ReadSettings()
-		if err != nil {
-			return err
-		}
 		client, err := createTursoClientFromAccessToken(true)
 		if err != nil {
 			return err
 		}
-		databases, err := client.Databases.List()
+		databases, err := getDatabasesCacheOrAPI(client)
 		if err != nil {
 			return err
 		}
-
-		settings.SetDbNamesCache(extractDatabaseNames(databases))
 
 		var data [][]string
 		for _, database := range databases {

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -141,7 +141,7 @@ func destroyDatabase(client *turso.Client, name string) error {
 	fmt.Printf("Destroyed database %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
 	settings, err := settings.ReadSettings()
 	if err == nil {
-		settings.InvalidateDbNamesCache()
+		settings.InvalidateDatabasesCache()
 	}
 
 	return nil

--- a/internal/settings/cache.go
+++ b/internal/settings/cache.go
@@ -52,23 +52,33 @@ func invalidateCache[T any](key string) error {
 	return setCacheWithExp[T](key, 0, *new(T))
 }
 
-const DB_NAMES_CACHE_KEY = "database_names"
-const DB_NAMES_CACHE_TTL_SECONDS = 30 * 60
+const DB_CACHE_KEY = "database_names"
+const DB_CACHE_TTL_SECONDS = 30 * 60
 
-func (s *Settings) SetDbNamesCache(dbNames []string) {
-	setCache(DB_NAMES_CACHE_KEY, DB_NAMES_CACHE_TTL_SECONDS, dbNames)
+// Database is exact same struct as turso.Database, but recreated to
+// avoid cyclic dependency.
+type Database struct {
+	ID            string
+	Name          string
+	Regions       []string
+	PrimaryRegion string
+	Hostname      string
 }
 
-func (s *Settings) GetDbNamesCache() []string {
-	data, err := getCache[[]string](DB_NAMES_CACHE_KEY)
+func (s *Settings) SetDatabasesCache(dbNames []Database) {
+	setCache(DB_CACHE_KEY, DB_CACHE_TTL_SECONDS, dbNames)
+}
+
+func (s *Settings) GetDatabasesCache() []Database {
+	data, err := getCache[[]Database](DB_CACHE_KEY)
 	if err != nil {
 		return nil
 	}
 	return data
 }
 
-func (s *Settings) InvalidateDbNamesCache() {
-	invalidateCache[[]string](DB_NAMES_CACHE_KEY)
+func (s *Settings) InvalidateDatabasesCache() {
+	invalidateCache[[]Database](DB_CACHE_KEY)
 }
 
 const REGIONS_CACHE_KEY = "locations"


### PR DESCRIPTION
The idea is to save the `client.Databases.List()` response locally. At first, I thought I could just save this struct, however this introduces a cyclic dependency between `settings` and `turso` module. So I created a new struct which resembles it and added helper methods to convert between them.

I also renamed caching methods like `GetDbNamesCache` to `GetDatabasesCache` since we aren't storing the names anymore, but full metadata. 

I did keep the same key name in the config `database_names` otherwise that key would remain unused in the file. (side note: I think similar thing happened to `cached_db_names` as I can't find any references to it in the codebase)

--- 

Another alternative would be moving the `turso.Database` to a common place, but that would require more changes and I also felt that is unnecessary.