### PR TITLE
feat: add debug flag to show outgoing http requests dumps

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/chiselstrike/iku-turso-cli/internal/flags"
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,4 +36,6 @@ func init() {
 		settings.PersistChanges()
 	}
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+
+	flags.AddDebugFlag(rootCmd)
 }

--- a/internal/flags/debug.go
+++ b/internal/flags/debug.go
@@ -1,0 +1,16 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var debugFlag bool
+
+func AddDebugFlag(cmd *cobra.Command) {
+	usage := "If set, shows dumps of all outgoing HTTP requests."
+	cmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, usage)
+}
+
+func Debug() bool {
+	return debugFlag
+}

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -6,8 +6,11 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
+
+	"github.com/chiselstrike/iku-turso-cli/internal/flags"
 )
 
 // Collection of all turso clients
@@ -79,6 +82,13 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 
 func (t *Client) do(method, path string, body io.Reader) (*http.Response, error) {
 	req, err := t.newRequest(method, path, body)
+	if flags.Debug() {
+		dump, err := httputil.DumpRequestOut(req, true)
+		fmt.Printf("%s", string(dump))
+		if err != nil {
+			return nil, err
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added a `--debug` flag to all commands in order to show dumps of outgoing http requests.

Example:

<img width="1440" alt="Screen Shot 2023-07-04 at 10 59 51 AM" src="https://github.com/chiselstrike/turso-cli/assets/11340665/87180b99-7694-4619-81d2-64485a6de309">
