### PR TITLE
fix: add user agent header

### DIFF
--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -77,7 +77,7 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 		req.Header.Add("Authorization", fmt.Sprint("Bearer ", t.token))
 	}
 	req.Header.Add("TursoCliVersion", t.cliVersion)
-	req.Header.Add("User-Agent", fmt.Sprintf("Turso CLI/%s (%s/%s)", t.cliVersion[1:], runtime.GOOS, runtime.GOARCH))
+	req.Header.Add("User-Agent", fmt.Sprintf("turso-cli/%s (%s/%s)", t.cliVersion[1:], runtime.GOOS, runtime.GOARCH))
 	req.Header.Add("Content-Type", "application/json")
 	return req, nil
 }

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"runtime"
 
 	"github.com/chiselstrike/iku-turso-cli/internal/flags"
 )
@@ -76,7 +77,7 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 		req.Header.Add("Authorization", fmt.Sprint("Bearer ", t.token))
 	}
 	req.Header.Add("TursoCliVersion", t.cliVersion)
-	req.Header.Add("User-Agent", fmt.Sprintf("Turso CLI - version %s", t.cliVersion))
+	req.Header.Add("User-Agent", fmt.Sprintf("Turso CLI/%s (%s/%s)", t.cliVersion[1:], runtime.GOOS, runtime.GOARCH))
 	req.Header.Add("Content-Type", "application/json")
 	return req, nil
 }

--- a/internal/turso/turso.go
+++ b/internal/turso/turso.go
@@ -76,6 +76,7 @@ func (t *Client) newRequest(method, urlPath string, body io.Reader) (*http.Reque
 		req.Header.Add("Authorization", fmt.Sprint("Bearer ", t.token))
 	}
 	req.Header.Add("TursoCliVersion", t.cliVersion)
+	req.Header.Add("User-Agent", fmt.Sprintf("Turso CLI - version %s", t.cliVersion))
 	req.Header.Add("Content-Type", "application/json")
 	return req, nil
 }


### PR DESCRIPTION
Should we delete the header `TursoCliVersion`?

closes https://github.com/chiselstrike/turso-cli/issues/517