### PR TITLE
fix: invalidate cache on switch org

### DIFF
--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -62,7 +62,7 @@ func switchToOrg(client *turso.Client, slug string) error {
 	fmt.Printf("Current organization set to %s.\n", internal.Emph(org.Slug))
 	fmt.Printf("All your %s commands will be executed in that organization context.\n", internal.Emph("turso"))
 	fmt.Printf("To switch back to your previous organization:\n\n\t%s\n", internal.Emph(prev))
-
+	settings.InvalidateDatabasesCache()
 	return nil
 }
 


### PR DESCRIPTION
It is showing dbs from other orgs when we switch.