### PR TITLE
Use the new `/usage` API format

### DIFF
--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -109,15 +109,15 @@ var dbInspectCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Total space used: %s\n", humanize.Bytes(dbUsage.Usage.Total.StorageBytesUsed))
-		fmt.Printf("Number of rows read: %d\n", dbUsage.Usage.Total.RowsRead)
-		fmt.Printf("Number of rows written: %d\n", dbUsage.Usage.Total.RowsWritten)
+		fmt.Printf("Total space used: %s\n", humanize.Bytes(dbUsage.Usage.StorageBytesUsed))
+		fmt.Printf("Number of rows read: %d\n", dbUsage.Usage.RowsRead)
+		fmt.Printf("Number of rows written: %d\n", dbUsage.Usage.RowsWritten)
 
 		if !verboseFlag {
 			return nil
 		}
 
-		instancesUsage := getInstanceUsageMap(dbUsage.Usage.Instances)
+		instancesUsage := getInstanceUsageMap(dbUsage.Instances)
 		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "ROWS WRITTEN", "TOTAL STORAGE")
 		for _, instance := range instances {
 			usg, ok := instancesUsage[instance.Uuid]
@@ -136,10 +136,10 @@ var dbInspectCmd = &cobra.Command{
 	},
 }
 
-func getInstanceUsageMap(usages []turso.Usage) map[string]turso.Usage {
+func getInstanceUsageMap(usages []turso.InstanceUsage) map[string]turso.Usage {
 	m := make(map[string]turso.Usage)
 	for _, usg := range usages {
-		m[usg.UUID] = usg
+		m[usg.UUID] = usg.Usage
 	}
 	return m
 }

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -120,7 +120,6 @@ var dbInspectCmd = &cobra.Command{
 		instancesUsage := getInstanceUsageMap(dbUsage.Usage.Instances)
 		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "ROWS WRITTEN", "TOTAL STORAGE")
 		for _, instance := range instances {
-			fmt.Printf("Instance: %s\n", instance.Uuid)
 			usg, ok := instancesUsage[instance.Uuid]
 			if !ok {
 				tbl.AddRow(instance.Region, instance.Type, instance.Name, "-", "-", "-")

--- a/internal/cmd/db_inspect.go
+++ b/internal/cmd/db_inspect.go
@@ -120,6 +120,7 @@ var dbInspectCmd = &cobra.Command{
 		instancesUsage := getInstanceUsageMap(dbUsage.Usage.Instances)
 		tbl := table.New("LOCATION", "TYPE", "INSTANCE NAME", "ROWS READ", "ROWS WRITTEN", "TOTAL STORAGE")
 		for _, instance := range instances {
+			fmt.Printf("Instance: %s\n", instance.Uuid)
 			usg, ok := instancesUsage[instance.Uuid]
 			if !ok {
 				tbl.AddRow(instance.Region, instance.Type, instance.Name, "-", "-", "-")

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -46,7 +46,7 @@ var showCmd = &cobra.Command{
 			return nil
 		}
 
-		instances, usages, err := instancesAndUsage(client, db.Name)
+		instances, dbUsage, err := instancesAndUsage(client, db.Name)
 		if err != nil {
 			return fmt.Errorf("could not get instances of database %s: %w", db.Name, err)
 		}
@@ -84,7 +84,7 @@ var showCmd = &cobra.Command{
 		fmt.Println("URL:           ", getDatabaseUrl(&db))
 		fmt.Println("ID:            ", db.ID)
 		fmt.Println("Locations:     ", strings.Join(regions, ", "))
-		fmt.Println("Size:          ", humanize.Bytes(usages.Total.StorageBytesUsed))
+		fmt.Println("Size:          ", humanize.Bytes(dbUsage.Usage.Total.StorageBytesUsed))
 		fmt.Println()
 		fmt.Print("Database Instances:\n")
 		printTable(headers, data)

--- a/internal/cmd/db_show.go
+++ b/internal/cmd/db_show.go
@@ -84,7 +84,7 @@ var showCmd = &cobra.Command{
 		fmt.Println("URL:           ", getDatabaseUrl(&db))
 		fmt.Println("ID:            ", db.ID)
 		fmt.Println("Locations:     ", strings.Join(regions, ", "))
-		fmt.Println("Size:          ", humanize.Bytes(dbUsage.Usage.Total.StorageBytesUsed))
+		fmt.Println("Size:          ", humanize.Bytes(dbUsage.Usage.StorageBytesUsed))
 		fmt.Println()
 		fmt.Print("Database Instances:\n")
 		printTable(headers, data)

--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -41,7 +41,7 @@ var planShowCmd = &cobra.Command{
 			return err
 		}
 
-		plan, usage, plans, err := orgPlanData(client)
+		plan, orgUsage, plans, err := orgPlanData(client)
 		if err != nil {
 			return err
 		}
@@ -65,11 +65,11 @@ var planShowCmd = &cobra.Command{
 		columnFmt := color.New(color.FgBlue, color.Bold).SprintfFunc()
 		tbl.WithFirstColumnFormatter(columnFmt)
 
-		addResourceRowBytes(tbl, "storage", usage.Total.StorageBytesUsed, current.Quotas.Storage)
-		addResourceRowMillions(tbl, "rows read", usage.Total.RowsRead, current.Quotas.RowsRead)
-		addResourceRowMillions(tbl, "rows written", usage.Total.RowsWritten, current.Quotas.RowsWritten)
-		addResourceRowCount(tbl, "databases", usage.Total.Databases, current.Quotas.Databases)
-		addResourceRowCount(tbl, "locations", usage.Total.Locations, current.Quotas.Locations)
+		addResourceRowBytes(tbl, "storage", orgUsage.Usage.StorageBytesUsed, current.Quotas.Storage)
+		addResourceRowMillions(tbl, "rows read", orgUsage.Usage.RowsRead, current.Quotas.RowsRead)
+		addResourceRowMillions(tbl, "rows written", orgUsage.Usage.RowsWritten, current.Quotas.RowsWritten)
+		addResourceRowCount(tbl, "databases", orgUsage.Usage.Databases, current.Quotas.Databases)
+		addResourceRowCount(tbl, "locations", orgUsage.Usage.Locations, current.Quotas.Locations)
 		tbl.Print()
 
 		return nil

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -226,6 +226,8 @@ func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
 	defer r.Body.Close()
 
 	body, err := unmarshal[DbUsage](r)
+
+	fmt.Printf("\nbody: %v\n", body)
 	return body, err
 }
 

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -226,8 +226,6 @@ func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
 	defer r.Body.Close()
 
 	body, err := unmarshal[DbUsage](r)
-
-	fmt.Printf("\nbody: %v\n", body)
 	return body, err
 }
 

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -200,14 +200,20 @@ func (d *DatabasesClient) Update(database string) error {
 }
 
 type Usage struct {
+	UUID             string `json:"uuid,omitempty"`
 	RowsRead         uint64 `json:"rows_read,omitempty"`
 	RowsWritten      uint64 `json:"rows_written,omitempty"`
 	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
 }
 
+type InstancesUsage struct {
+	Instances []Usage `json:"instances"`
+	Total     Usage   `json:"total"`
+}
+
 type DbUsage struct {
-	Instances map[string]Usage `json:"instances"`
-	Total     Usage            `json:"total"`
+	UUID  string         `json:"uuid,omitempty"`
+	Usage InstancesUsage `json:"usage"`
 }
 
 func (d *DatabasesClient) Usage(database string) (DbUsage, error) {

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -206,14 +206,19 @@ type Usage struct {
 	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`
 }
 
-type InstancesUsage struct {
-	Instances []Usage `json:"instances"`
-	Total     Usage   `json:"total"`
+type InstanceUsage struct {
+	UUID  string `json:"uuid,omitempty"`
+	Usage Usage  `json:"usage"`
 }
 
 type DbUsage struct {
-	UUID  string         `json:"uuid,omitempty"`
-	Usage InstancesUsage `json:"usage"`
+	UUID      string          `json:"uuid,omitempty"`
+	Instances []InstanceUsage `json:"instances"`
+	Usage     Usage           `json:"usage"`
+}
+
+type DbUsageResponse struct {
+	DbUsage DbUsage `json:"database"`
 }
 
 func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
@@ -225,8 +230,11 @@ func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
 	}
 	defer r.Body.Close()
 
-	body, err := unmarshal[DbUsage](r)
-	return body, err
+	body, err := unmarshal[DbUsageResponse](r)
+	if err != nil {
+		return DbUsage{}, err
+	}
+	return body.DbUsage, nil
 }
 
 func (d *DatabasesClient) URL(suffix string) string {

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -237,6 +237,11 @@ func (d *DatabasesClient) Usage(database string) (DbUsage, error) {
 	}
 	defer r.Body.Close()
 
+	if r.StatusCode != http.StatusOK {
+		err, _ := unmarshal[string](r)
+		return DbUsage{}, fmt.Errorf("failed to get database usage: %d %s", r.StatusCode, err)
+	}
+
 	body, err := unmarshal[DbUsageResponse](r)
 	if err != nil {
 		return DbUsage{}, err

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -200,7 +200,6 @@ func (d *DatabasesClient) Update(database string) error {
 }
 
 type Usage struct {
-	UUID             string `json:"uuid,omitempty"`
 	RowsRead         uint64 `json:"rows_read,omitempty"`
 	RowsWritten      uint64 `json:"rows_written,omitempty"`
 	StorageBytesUsed uint64 `json:"storage_bytes,omitempty"`

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -100,8 +100,13 @@ type OrgTotal struct {
 }
 
 type OrgUsage struct {
-	Databases map[string]DbUsage `json:"databases"`
-	Total     OrgTotal           `json:"total"`
+	UUID      string    `json:"uuid,omitempty"`
+	Usage     OrgTotal  `json:"usage"`
+	Databases []DbUsage `json:"databases"`
+}
+
+type OrgUsageResponse struct {
+	OrgUsage OrgUsage `json:"organization"`
 }
 
 func (c *OrganizationsClient) Usage() (OrgUsage, error) {
@@ -116,8 +121,11 @@ func (c *OrganizationsClient) Usage() (OrgUsage, error) {
 	}
 	defer r.Body.Close()
 
-	body, err := unmarshal[OrgUsage](r)
-	return body, err
+	body, err := unmarshal[OrgUsageResponse](r)
+	if err != nil {
+		return OrgUsage{}, err
+	}
+	return body.OrgUsage, nil
 }
 
 type Member struct {

--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -121,6 +121,11 @@ func (c *OrganizationsClient) Usage() (OrgUsage, error) {
 	}
 	defer r.Body.Close()
 
+	if r.StatusCode != http.StatusOK {
+		err, _ := unmarshal[string](r)
+		return OrgUsage{}, fmt.Errorf("failed to get database usage: %d %s", r.StatusCode, err)
+	}
+
 	body, err := unmarshal[OrgUsageResponse](r)
 	if err != nil {
 		return OrgUsage{}, err

--- a/internal/turso/utils.go
+++ b/internal/turso/utils.go
@@ -16,6 +16,9 @@ func unmarshal[T any](r *http.Response) (T, error) {
 	if err != nil {
 		return *t, err
 	}
+
+	fmt.Printf("\ndata: %s\n\n", d)
+
 	err = json.Unmarshal(d, &t)
 	return *t, err
 }

--- a/internal/turso/utils.go
+++ b/internal/turso/utils.go
@@ -16,9 +16,6 @@ func unmarshal[T any](r *http.Response) (T, error) {
 	if err != nil {
 		return *t, err
 	}
-
-	fmt.Printf("\ndata: %s\n\n", d)
-
 	err = json.Unmarshal(d, &t)
 	return *t, err
 }


### PR DESCRIPTION
Updated the CLI to use the new API format:

<details><summary> `/v1/databases/database-name/usage`</summary> 

```json
{
    "database": {
        "uuid": "61a4bda2-1fee-11ee-ac04-acde48001122",
        "instances": [
            {
                "uuid": "63b73534-1fee-11ee-ac04-acde48001122",
                "usage": {
                    "rows_read": 76544,
                    "rows_written": 49978,
                    "storage_bytes": 2325928
                }
            },
            {
                "uuid": "722ffc4a-1fee-11ee-ac04-acde48001122",
                "usage": {
                    "rows_read": 96544,
                    "rows_written": 79978,
                    "storage_bytes": 12325928
                }
            }
        ],
        "usage": {
            "rows_read": 173088,
            "rows_written": 129956,
            "storage_bytes": 14651856
        }
    },
    "instances": {
        "63b73534-1fee-11ee-ac04-acde48001122": {
            "rows_read": 76544,
            "rows_written": 49978,
            "storage_bytes": 2325928
        },
        "722ffc4a-1fee-11ee-ac04-acde48001122": {
            "rows_read": 96544,
            "rows_written": 79978,
            "storage_bytes": 12325928
        }
    },
    "total": {
        "rows_read": 173088,
        "rows_written": 129956,
        "storage_bytes": 14651856
    }
}
```
</details>

<details><summary>`/v1/usage`</summary> 

```json
{
    "organization": {
        "uuid": "ef94e641-a696-46d8-aa07-fc304b93e283",
        "usage": {
            "rows_read": 173088,
            "rows_written": 129956,
            "storage_bytes": 14651856,
            "databases": 2,
            "locations": 3
        },
        "databases": [
            {
                "uuid": "61a4bda2-1fee-11ee-ac04-acde48001122",
                "instances": [
                    {
                        "uuid": "63b73534-1fee-11ee-ac04-acde48001122",
                        "usage": {
                            "rows_read": 76544,
                            "rows_written": 49978,
                            "storage_bytes": 2325928
                        }
                    },
                    {
                        "uuid": "722ffc4a-1fee-11ee-ac04-acde48001122",
                        "usage": {
                            "rows_read": 96544,
                            "rows_written": 79978,
                            "storage_bytes": 12325928
                        }
                    }
                ],
                "usage": {
                    "rows_read": 173088,
                    "rows_written": 129956,
                    "storage_bytes": 14651856
                }
            }
        ]
    },
    "databases": {
        "61a4bda2-1fee-11ee-ac04-acde48001122": {
            "instances": {
                "63b73534-1fee-11ee-ac04-acde48001122": {
                    "rows_read": 76544,
                    "rows_written": 49978,
                    "storage_bytes": 2325928
                },
                "722ffc4a-1fee-11ee-ac04-acde48001122": {
                    "rows_read": 96544,
                    "rows_written": 79978,
                    "storage_bytes": 12325928
                }
            },
            "total": {
                "rows_read": 173088,
                "rows_written": 129956,
                "storage_bytes": 14651856
            }
        }
    },
    "total": {
        "rows_read": 173088,
        "rows_written": 129956,
        "storage_bytes": 14651856,
        "databases": 2,
        "locations": 3
    }
}
```
</details>