### PR TITLE
Bugfix: Refresh cache on DB list API call

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -102,8 +102,7 @@ func isJwtTokenValid(token string) bool {
 	if len(token) == 0 {
 		return false
 	}
-	settings, _ := settings.ReadSettings()
-	if settings.TokenValidCache(token) {
+	if tokenValidCache(token) {
 		return true
 	}
 	client, err := tursoClient(token)
@@ -114,7 +113,7 @@ func isJwtTokenValid(token string) bool {
 	if err != nil {
 		return false
 	}
-	settings.SetTokenValidCache(token, exp)
+	setTokenValidCache(token, exp)
 	return true
 }
 

--- a/internal/cmd/cache.go
+++ b/internal/cmd/cache.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/chiselstrike/iku-turso-cli/internal/settings"
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+)
+
+const DB_CACHE_KEY = "database_names"
+const DB_CACHE_TTL_SECONDS = 30 * 60
+
+func setDatabasesCache(dbNames []turso.Database) {
+	settings.SetCache(DB_CACHE_KEY, DB_CACHE_TTL_SECONDS, dbNames)
+}
+
+func getDatabasesCache() []turso.Database {
+	data, err := settings.GetCache[[]turso.Database](DB_CACHE_KEY)
+	if err != nil {
+		return nil
+	}
+	fmt.Printf("cache hit: %v\n", data)
+	return data
+}
+
+func invalidateDatabasesCache() {
+	settings.InvalidateCache[[]turso.Database](DB_CACHE_KEY)
+}
+
+const REGIONS_CACHE_KEY = "locations"
+const REGIONS_CACHE_TTL_SECONDS = 8 * 60 * 60
+
+func setLocationsCache(locations map[string]string) {
+	settings.SetCache(REGIONS_CACHE_KEY, REGIONS_CACHE_TTL_SECONDS, locations)
+}
+
+func locationsCache() map[string]string {
+	locations, err := settings.GetCache[map[string]string](REGIONS_CACHE_KEY)
+	if err != nil {
+		return nil
+	}
+	return locations
+}
+
+const CLOSEST_LOCATION_CACHE_KEY = "closestLocation"
+
+func setClosestLocationCache(closest string) {
+	settings.SetCache(CLOSEST_LOCATION_CACHE_KEY, REGIONS_CACHE_TTL_SECONDS, closest)
+}
+
+func closestLocationCache() string {
+	defaultLocation, err := settings.GetCache[string](CLOSEST_LOCATION_CACHE_KEY)
+	if err != nil {
+		return ""
+	}
+	return defaultLocation
+}
+
+const TOKEN_VALID_CACHE_KEY_PREFIX = "token_valid."
+
+func setTokenValidCache(token string, exp int64) {
+	key := TOKEN_VALID_CACHE_KEY_PREFIX + strings.ReplaceAll(token, ".", "_")
+	settings.SetCacheWithExp(key, exp, true)
+}
+
+func tokenValidCache(token string) bool {
+	key := TOKEN_VALID_CACHE_KEY_PREFIX + strings.ReplaceAll(token, ".", "_")
+	ok, err := settings.GetCache[bool](key)
+	return err == nil && ok
+}
+
+const DATABASE_TOKEN_KEY_PREFIX = "database_token."
+
+func setDbTokenCache(dbID, token string, exp int64) {
+	key := DATABASE_TOKEN_KEY_PREFIX + dbID
+	settings.SetCacheWithExp(key, exp, token)
+}
+
+func dbTokenCache(dbID string) string {
+	key := DATABASE_TOKEN_KEY_PREFIX + dbID
+	token, err := settings.GetCache[string](key)
+	if err != nil {
+		return ""
+	}
+	return token
+}

--- a/internal/cmd/cache.go
+++ b/internal/cmd/cache.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/chiselstrike/iku-turso-cli/internal/settings"
@@ -20,7 +19,6 @@ func getDatabasesCache() []turso.Database {
 	if err != nil {
 		return nil
 	}
-	fmt.Printf("cache hit: %v\n", data)
 	return data
 }
 

--- a/internal/cmd/cache_test.go
+++ b/internal/cmd/cache_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chiselstrike/iku-turso-cli/internal/turso"
+	"github.com/google/uuid"
+)
+
+func Test_setDatabasesCache(t *testing.T) {
+	dbNames := []turso.Database{
+		{
+			Name:          "name",
+			ID:            "id",
+			Regions:       []string{"waw"},
+			PrimaryRegion: "waw",
+			Hostname:      "hostname",
+		},
+		{
+			Name:          "name2",
+			ID:            "id2",
+			Regions:       []string{"waw", "ams"},
+			PrimaryRegion: "ams",
+			Hostname:      "hostname2",
+		},
+	}
+	setDatabasesCache(dbNames)
+	if !reflect.DeepEqual(getDatabasesCache(), dbNames) {
+		t.Errorf("setDatabasesCache() = %v, want %v", getDatabasesCache(), dbNames)
+	}
+}
+
+func Test_closestLocationCache(t *testing.T) {
+	loc := "waw"
+	setClosestLocationCache(loc)
+	if got := closestLocationCache(); got != loc {
+		t.Errorf("closestLocationCache() = %v, want %v", got, loc)
+	}
+}
+
+func Test_setDbTokenCache(t *testing.T) {
+	dbId := fmt.Sprintf("dbId-%s", uuid.NewString())
+	token := fmt.Sprintf("token-%s", uuid.NewString())
+	setDbTokenCache(dbId, token, time.Now().Add(10*time.Minute).Unix())
+	if got := dbTokenCache(dbId); got != token {
+		t.Errorf("getDbTokenCache() = %v, want %v", got, token)
+	}
+}
+
+func Test_setDbTokenCache_expired(t *testing.T) {
+	dbId := fmt.Sprintf("dbId-%s", uuid.NewString())
+	token := fmt.Sprintf("token-%s", uuid.NewString())
+	setDbTokenCache(dbId, token, time.Now().Add(-10*time.Minute).Unix())
+	if got := dbTokenCache(dbId); got != "" {
+		t.Errorf("getDbTokenCache() = %v", got)
+	}
+}
+
+func Test_setLocationsCache(t *testing.T) {
+	locs := map[string]string{
+		"ams": "Amsterdam, Netherlands",
+		"arn": "Stockholm, Sweden",
+	}
+	setLocationsCache(locs)
+	if !reflect.DeepEqual(locationsCache(), locs) {
+		t.Errorf("locationsCache() = %v, want %v", locationsCache(), locs)
+	}
+}

--- a/internal/cmd/db.go
+++ b/internal/cmd/db.go
@@ -39,7 +39,7 @@ func extractDatabaseNames(databases []turso.Database) []string {
 }
 
 func getDatabase(client *turso.Client, name string) (turso.Database, error) {
-	databases, err := client.Databases.List()
+	databases, err := getDatabases(client)
 	if err != nil {
 		return turso.Database{}, err
 	}
@@ -53,7 +53,7 @@ func getDatabase(client *turso.Client, name string) (turso.Database, error) {
 	return turso.Database{}, fmt.Errorf("database %s not found. List known databases using %s", internal.Emph(name), internal.Emph("turso db list"))
 }
 
-func getDatabasesCacheOrAPI(client *turso.Client) ([]turso.Database, error) {
+func getDatabases(client *turso.Client) ([]turso.Database, error) {
 	if cachedNames := getDatabasesCache(); cachedNames != nil {
 		return cachedNames, nil
 	}
@@ -66,7 +66,7 @@ func getDatabasesCacheOrAPI(client *turso.Client) ([]turso.Database, error) {
 }
 
 func getDatabaseNames(client *turso.Client) []string {
-	databases, err := getDatabasesCacheOrAPI(client)
+	databases, err := getDatabases(client)
 	if err != nil {
 		return []string{}
 	}

--- a/internal/cmd/db_create.go
+++ b/internal/cmd/db_create.go
@@ -231,9 +231,7 @@ var createCmd = &cobra.Command{
 		fmt.Printf("   turso db show %s\n\n", name)
 		fmt.Printf("To get an authentication token for the database, run:\n\n")
 		fmt.Printf("   turso db tokens create %s\n\n", name)
-
-		config.InvalidateDatabasesCache()
-
+		invalidateDatabasesCache()
 		return nil
 	},
 }

--- a/internal/cmd/db_list.go
+++ b/internal/cmd/db_list.go
@@ -21,11 +21,11 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		databases, err := getDatabasesCacheOrAPI(client)
+		databases, err := client.Databases.List()
 		if err != nil {
 			return err
 		}
-
+		setDatabasesCache(databases)
 		var data [][]string
 		for _, database := range databases {
 			data = append(data, []string{

--- a/internal/cmd/db_replicate.go
+++ b/internal/cmd/db_replicate.go
@@ -150,7 +150,7 @@ var replicateCmd = &cobra.Command{
 			fmt.Printf("🗓   Book a call with us! You can do it with:\n\n\t%s\n", internal.Emph("turso account bookmeeting"))
 			fmt.Printf("🎤   Or just send us your feedback:\n\n\t%s\n", internal.Emph("turso account feedback"))
 		}
-
+		invalidateDatabasesCache()
 		return nil
 	},
 }

--- a/internal/cmd/db_shell.go
+++ b/internal/cmd/db_shell.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/chiselstrike/iku-turso-cli/internal"
 	"github.com/chiselstrike/iku-turso-cli/internal/prompt"
-	"github.com/chiselstrike/iku-turso-cli/internal/settings"
 	"github.com/chiselstrike/iku-turso-cli/internal/turso"
 	"github.com/libsql/libsql-shell-go/pkg/shell"
 	"github.com/libsql/libsql-shell-go/pkg/shell/enums"
@@ -177,8 +176,7 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 		return "", nil
 	}
 
-	settings, _ := settings.ReadSettings()
-	if token := settings.DbTokenCache(db.ID); token != "" {
+	if token := dbTokenCache(db.ID); token != "" {
 		return token, nil
 	}
 
@@ -188,7 +186,7 @@ func tokenFromDb(db *turso.Database, client *turso.Client) (string, error) {
 	}
 
 	exp := time.Now().Add(time.Hour * 23).Unix()
-	settings.SetDbTokenCache(db.ID, token, exp)
+	setDbTokenCache(db.ID, token, exp)
 
 	return token, nil
 }

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -63,7 +63,7 @@ func switchToOrg(client *turso.Client, slug string) error {
 	fmt.Printf("Current organization set to %s.\n", internal.Emph(org.Slug))
 	fmt.Printf("All your %s commands will be executed in that organization context.\n", internal.Emph("turso"))
 	fmt.Printf("To switch back to your previous organization:\n\n\t%s\n", internal.Emph(prev))
-	settings.InvalidateDatabasesCache()
+	invalidateDatabasesCache()
 	return nil
 }
 

--- a/internal/cmd/org.go
+++ b/internal/cmd/org.go
@@ -165,7 +165,7 @@ var orgDestroyCmd = &cobra.Command{
 		if err = client.Organizations.Delete(slug); err != nil {
 			return err
 		}
-
+		invalidateDatabasesCache()
 		fmt.Printf("Destroyed organization %s.\n", internal.Emph(slug))
 		return nil
 	},

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -139,11 +139,7 @@ func destroyDatabase(client *turso.Client, name string) error {
 	elapsed := time.Since(start)
 
 	fmt.Printf("Destroyed database %s in %d seconds.\n", internal.Emph(name), int(elapsed.Seconds()))
-	settings, err := settings.ReadSettings()
-	if err == nil {
-		settings.InvalidateDatabasesCache()
-	}
-
+	invalidateDatabasesCache()
 	return nil
 }
 

--- a/internal/settings/cache.go
+++ b/internal/settings/cache.go
@@ -3,7 +3,6 @@ package settings
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -21,120 +20,30 @@ func cacheKey(key string) string {
 	return "cache." + key
 }
 
-func setCache[T any](key string, ttl int64, value T) error {
+func SetCache[T any](key string, ttl int64, value T) error {
 	exp := time.Now().Unix() + ttl
-	return setCacheWithExp(key, exp, value)
+	return SetCacheWithExp(key, exp, value)
 }
 
-func setCacheWithExp[T any](key string, exp int64, value T) error {
-	entry := Entry[T]{Data: value}
-	entry.Expiration = exp
+func SetCacheWithExp[T any](key string, exp int64, value T) error {
+	entry := Entry[T]{Data: value, Expiration: exp}
 	viper.Set(cacheKey(key), entry)
 	settings.changed = true
 	return nil
 }
 
-func getCache[T any](key string) (T, error) {
+func GetCache[T any](key string) (T, error) {
 	entry := Entry[T]{}
 	value := viper.Get(cacheKey(key))
 	if err := mapstructure.Decode(value, &entry); err != nil {
 		return entry.Data, fmt.Errorf("failed to get cache data for %s", key)
 	}
-
 	if entry.Expiration < time.Now().Unix() {
 		return entry.Data, ErrExpired
 	}
-
 	return entry.Data, nil
 }
 
-func invalidateCache[T any](key string) error {
-	return setCacheWithExp[T](key, 0, *new(T))
-}
-
-const DB_CACHE_KEY = "database_names"
-const DB_CACHE_TTL_SECONDS = 30 * 60
-
-// Database is exact same struct as turso.Database, but recreated to
-// avoid cyclic dependency.
-type Database struct {
-	ID            string
-	Name          string
-	Regions       []string
-	PrimaryRegion string
-	Hostname      string
-}
-
-func (s *Settings) SetDatabasesCache(dbNames []Database) {
-	setCache(DB_CACHE_KEY, DB_CACHE_TTL_SECONDS, dbNames)
-}
-
-func (s *Settings) GetDatabasesCache() []Database {
-	data, err := getCache[[]Database](DB_CACHE_KEY)
-	if err != nil {
-		return nil
-	}
-	return data
-}
-
-func (s *Settings) InvalidateDatabasesCache() {
-	invalidateCache[[]Database](DB_CACHE_KEY)
-}
-
-const REGIONS_CACHE_KEY = "locations"
-const REGIONS_CACHE_TTL_SECONDS = 8 * 60 * 60
-
-func (s *Settings) SetLocationsCache(locations map[string]string) {
-	setCache(REGIONS_CACHE_KEY, REGIONS_CACHE_TTL_SECONDS, locations)
-}
-
-func (s *Settings) LocationsCache() map[string]string {
-	locations, err := getCache[map[string]string](REGIONS_CACHE_KEY)
-	if err != nil {
-		return nil
-	}
-	return locations
-}
-
-const CLOSEST_LOCATION_CACHE_KEY = "closestLocation"
-
-func (s *Settings) SetClosestLocationCache(closest string) {
-	setCache(CLOSEST_LOCATION_CACHE_KEY, REGIONS_CACHE_TTL_SECONDS, closest)
-}
-
-func (s *Settings) ClosestLocationCache() string {
-	defaultLocation, err := getCache[string](CLOSEST_LOCATION_CACHE_KEY)
-	if err != nil {
-		return ""
-	}
-	return defaultLocation
-}
-
-const TOKEN_VALID_CACHE_KEY_PREFIX = "token_valid."
-
-func (s *Settings) SetTokenValidCache(token string, exp int64) {
-	key := TOKEN_VALID_CACHE_KEY_PREFIX + strings.ReplaceAll(token, ".", "_")
-	setCacheWithExp(key, exp, true)
-}
-
-func (s *Settings) TokenValidCache(token string) bool {
-	key := TOKEN_VALID_CACHE_KEY_PREFIX + strings.ReplaceAll(token, ".", "_")
-	ok, err := getCache[bool](key)
-	return err == nil && ok
-}
-
-const DATABASE_TOKEN_KEY_PREFIX = "database_token."
-
-func (s *Settings) SetDbTokenCache(dbID, token string, exp int64) {
-	key := DATABASE_TOKEN_KEY_PREFIX + dbID
-	setCacheWithExp(key, exp, token)
-}
-
-func (s *Settings) DbTokenCache(dbID string) string {
-	key := DATABASE_TOKEN_KEY_PREFIX + dbID
-	token, err := getCache[string](key)
-	if err != nil {
-		return ""
-	}
-	return token
+func InvalidateCache[T any](key string) error {
+	return SetCacheWithExp[T](key, 0, *new(T))
 }

--- a/internal/settings/cache.go
+++ b/internal/settings/cache.go
@@ -26,6 +26,9 @@ func SetCache[T any](key string, ttl int64, value T) error {
 }
 
 func SetCacheWithExp[T any](key string, exp int64, value T) error {
+	if _, err := ReadSettings(); err != nil {
+		return err
+	}
 	entry := Entry[T]{Data: value, Expiration: exp}
 	viper.Set(cacheKey(key), entry)
 	settings.changed = true
@@ -34,6 +37,9 @@ func SetCacheWithExp[T any](key string, exp int64, value T) error {
 
 func GetCache[T any](key string) (T, error) {
 	entry := Entry[T]{}
+	if _, err := ReadSettings(); err != nil {
+		return entry.Data, err
+	}
 	value := viper.Get(cacheKey(key))
 	if err := mapstructure.Decode(value, &entry); err != nil {
 		return entry.Data, fmt.Errorf("failed to get cache data for %s", key)

--- a/internal/turso/databases.go
+++ b/internal/turso/databases.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Database struct {
-	ID            string `json:"dbId"`
+	ID            string `json:"dbId" mapstructure:"dbId"`
 	Name          string
 	Regions       []string
 	PrimaryRegion string


### PR DESCRIPTION
closes #531 

I introduced a bug in #515 where I was caching the DB list API response. This PR fixes the issue and adds some more changes: 

- `db list` call always hits the API and refreshes the cache
- other commands which use db details, hit the cache first 
- made the caching layer generic and moved the helper methods to `cmd` module