### PR TITLE
Get org destroy error from API response

### DIFF
--- a/internal/turso/organizations.go
+++ b/internal/turso/organizations.go
@@ -83,7 +83,7 @@ func (c *OrganizationsClient) Delete(slug string) error {
 	case http.StatusOK:
 		return nil
 	case http.StatusBadRequest:
-		return fmt.Errorf("cannot delete personal organization %s", slug)
+		return parseResponseError(r)
 	case http.StatusForbidden:
 		return fmt.Errorf("you do not have permission to delete organization %s", slug)
 	default:


### PR DESCRIPTION
Examples:
```
➜  turso git:(main) ✗ turso org destroy foo
Error: organization foo has databases so it cannot be deleted
```
```
➜  turso git:(main) ✗ turso org destroy athoscouto
Error: cannot delete personal organization athoscouto
```