### PR TITLE
Display when quota will reset

### DIFF
--- a/internal/cmd/plan.go
+++ b/internal/cmd/plan.go
@@ -71,7 +71,7 @@ var planShowCmd = &cobra.Command{
 		addResourceRowCount(tbl, "databases", usage.Total.Databases, current.Quotas.Databases)
 		addResourceRowCount(tbl, "locations", usage.Total.Locations, current.Quotas.Locations)
 		tbl.Print()
-
+		fmt.Printf("\nQuota will reset on %s\n", getFirstDayOfNextMonth().Local().Format(time.RFC1123))
 		return nil
 	},
 }
@@ -348,4 +348,13 @@ func addResourceRowCount(tbl table.Table, resource string, used, limit uint64) {
 
 func percentage(used, limit float64) string {
 	return fmt.Sprintf("%.0f%%", used/limit*100)
+}
+
+func getFirstDayOfNextMonth() time.Time {
+	now := time.Now().UTC()
+	nextMonth := now.AddDate(0, 1, 0)
+	year := nextMonth.Year()
+	month := nextMonth.Month()
+	firstDay := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	return firstDay
 }


### PR DESCRIPTION
fixes #545 

It shows when the quota will be reset, the first day of coming month, in the user's timezone. 

```
$ turso plan show

Plan: starter

RESOURCE      USED   LIMIT   USED %
storage       15 MB  8.6 GB  0%
rows read     0.2M   1000M   0%
rows written  0.1M   25M     1%
databases     2      3       67%
locations     3      3       100%

Quota will reset on Tue, 01 Aug 2023 05:30:00 IST
```